### PR TITLE
[OT-59] [FEAT]: 검색 기능 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 node_modules/
 package-lock.json
 pnpm-lock.yaml
+

--- a/apps/api-user/src/main/java/com/ott/api_user/search/controller/SearchApi.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/search/controller/SearchApi.java
@@ -1,0 +1,36 @@
+package com.ott.api_user.search.controller;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.ott.common.web.exception.ErrorResponse;
+import com.ott.common.web.response.PageResponse;
+import com.ott.common.web.response.SuccessResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Tag(name = "Search API", description = "통합 검색 API입니다.")
+public interface SearchApi {
+
+    @Operation(summary = "통합 검색 API", description = "콘텐츠와 시리즈를 통합하여 최신순으로 검색합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 성공", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = PageResponse.class)) }),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (검색어 누락 등)", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)) })
+    })
+    @GetMapping
+    ResponseEntity<SuccessResponse<PageResponse>> search(
+            @Parameter(description = "검색어를 입력해주세요.", required = true) @RequestParam(value = "searchWord") String searchWord,
+
+            @Parameter(description = "조회할 페이지 번호를 입력해주세요. page는 0부터 시작합니다", required = true) @RequestParam(value = "page", defaultValue = "0") Integer page,
+
+            @Parameter(description = "한 페이지 당 최대 항목 개수를 입력해주세요. 기본값은 24입니다.", required = true) @RequestParam(value = "size", defaultValue = "24") Integer size);
+}

--- a/apps/api-user/src/main/java/com/ott/api_user/search/controller/SearchController.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/search/controller/SearchController.java
@@ -1,0 +1,32 @@
+package com.ott.api_user.search.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ott.api_user.search.service.SearchService;
+import com.ott.common.web.response.PageResponse;
+import com.ott.common.web.response.SuccessResponse;
+
+import jakarta.persistence.criteria.CriteriaBuilder.In;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/search")
+public class SearchController implements SearchApi {
+    private final SearchService searchService;
+
+    @Override
+    public ResponseEntity<SuccessResponse<PageResponse>> search(
+            @RequestParam String searchWord,
+            @RequestParam Integer page,
+            @RequestParam Integer size) {
+        PageResponse response = searchService.search(searchWord, page, size);
+        return ResponseEntity.ok(SuccessResponse.of(response));
+    }
+
+}

--- a/apps/api-user/src/main/java/com/ott/api_user/search/dto/SearchItemResponse.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/search/dto/SearchItemResponse.java
@@ -1,0 +1,32 @@
+package com.ott.api_user.search.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "검색 결과 항목 응답 DTO")
+public class SearchItemResponse {
+    @Schema(description = "항목 타입 (콘텐츠 또는 시리즈)", example = "CONTENTS")
+    private String type;
+
+    @Schema(description = "콘텐츠 또는 시리즈의 고유 ID", example = "101")
+    private Long id;
+
+    @Schema(description = "제목", example = "비밀의 숲")
+    private String title;
+
+    @Schema(description = "포스터 이미지 URL", example = "https://cdn.ott.com/posters/101.jpg")
+    private String posterUrl;
+
+    @JsonIgnore // JSON 응답에서는 제외
+    @Schema(description = "서버 내부 정렬용 생성일시", hidden = true)
+    private LocalDateTime createdAt;
+}

--- a/apps/api-user/src/main/java/com/ott/api_user/search/service/SearchService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/search/service/SearchService.java
@@ -1,0 +1,84 @@
+package com.ott.api_user.search.service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.ott.api_user.search.dto.SearchItemResponse;
+import com.ott.common.web.exception.BusinessException;
+import com.ott.common.web.exception.ErrorCode;
+import com.ott.common.web.response.PageInfo;
+import com.ott.common.web.response.PageResponse;
+import com.ott.domain.common.Status;
+import com.ott.domain.contents.repository.ContentsRepository;
+import com.ott.domain.series.domain.Series;
+import com.ott.domain.contents.domain.Contents;
+import com.ott.domain.series.repository.SeriesRepository;
+import lombok.RequiredArgsConstructor;
+
+// 최신순 정렬을 위해 DB 페이징 방식 대신, 
+// 검색 결과를 모두 가져와서 Java Stream으로 정렬 후, 페이지네이션 처리하는 방식으로 변경
+// 추후 검색 대상이 늘어나거나 데이터 양이 많아질 경우, Querydsl 으로 검색 쿼리 최적화 필요!
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+    private final ContentsRepository contentsRepository;
+    private final SeriesRepository seriesRepository;
+
+    public PageResponse search(String searchWord, int page, int size) {
+
+        if (searchWord.length() < 2) {
+            throw new BusinessException(ErrorCode.SEARCH_KEYWORD_TOO_SHORT);
+        }
+
+        // 사용자가 흔한 검색어 입력 시 너무 많은 데이터를 가져올 수 있으므로
+        // 일단 최대 100개까지만 가져오도록 제한
+        Pageable limit = PageRequest.of(0, 100);
+
+        // 에피소드 제외, 시리즈와 단일 콘텐츠만 검색
+        List<Contents> contentsList = contentsRepository.searchLatest(searchWord, Status.ACTIVE, limit);
+        List<Series> seriesList = seriesRepository.searchLatest(searchWord, Status.ACTIVE, limit);
+
+        // 컨텐츠+시리즈 통합 정렬
+        List<SearchItemResponse> allResults = Stream.concat(
+                contentsList.stream().map(c -> SearchItemResponse.builder()
+                        .type("CONTENTS")
+                        .id(c.getId())
+                        .title(c.getTitle())
+                        .posterUrl(c.getPosterUrl())
+                        .createdAt(c.getCreatedDate())
+                        .build()),
+                seriesList.stream().map(s -> SearchItemResponse.builder()
+                        .type("SERIES")
+                        .id(s.getId())
+                        .title(s.getTitle())
+                        .posterUrl(s.getPosterUrl())
+                        .createdAt(s.getCreatedDate())
+                        .build()))
+                .sorted(Comparator.comparing(SearchItemResponse::getCreatedAt).reversed()) // 통합 최신순 정렬
+                .toList();
+
+        // 페이징 계산 (직접 자르기)
+        int totalElements = allResults.size();
+        int totalPages = (int) Math.ceil((double) totalElements / size);
+
+        int start = Math.min(page * size, totalElements);
+        int end = Math.min(start + size, totalElements);
+
+        List<SearchItemResponse> pagedResult = allResults.subList(start, end);
+
+        PageInfo pageInfo = PageInfo.builder()
+                .currentPage(page)
+                .totalPage(totalPages)
+                .pageSize(size)
+                .build();
+
+        return PageResponse.toPageResponse(pageInfo, pagedResult);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,10 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u${MYSQL_USER} -p${MYSQL_PASSWORD} --silent"]
       interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 20
 
   # ============ 앱 ============
   api-admin:

--- a/modules/common-web/src/main/java/com/ott/common/web/config/WebMvcConfig.java
+++ b/modules/common-web/src/main/java/com/ott/common/web/config/WebMvcConfig.java
@@ -10,14 +10,13 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private final long MAX_AGE_SECS = 3600;
 
-//    @Value("${app.cors.allowed-origins}")
-//    private String[] allowedOrigins;
+    // @Value("${app.cors.allowed-origins}")
+    // private String[] allowedOrigins;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-//                .allowedOrigins(allowedOrigins)
-                .allowedOriginPatterns()
+                .allowedOriginPatterns("*")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/modules/common-web/src/main/java/com/ott/common/web/exception/ErrorCode.java
+++ b/modules/common-web/src/main/java/com/ott/common/web/exception/ErrorCode.java
@@ -38,7 +38,8 @@ public enum ErrorCode {
 
     // ========== Business (B) - 비즈니스 ==========
     CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "콘텐츠를 찾을 수 없습니다"),
-    SERIES_NOT_FOUND(HttpStatus.NOT_FOUND, "B002", "시리즈를 찾을 수 없습니다");
+    SERIES_NOT_FOUND(HttpStatus.NOT_FOUND, "B002", "시리즈를 찾을 수 없습니다"),
+    SEARCH_KEYWORD_TOO_SHORT(HttpStatus.BAD_REQUEST, "B003", "검색어는 최소 2글자 이상이어야 합니다"),;
 
     private final HttpStatus status;
     private final String code;

--- a/modules/domain/src/main/java/com/ott/domain/contents/repository/ContentsRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/contents/repository/ContentsRepository.java
@@ -1,0 +1,24 @@
+package com.ott.domain.contents.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ott.domain.common.Status;
+import com.ott.domain.contents.domain.Contents;
+
+public interface ContentsRepository extends JpaRepository<Contents, Long> {
+
+    // 제목에 검색어 포함, 상태 ACTIVE, 시리즈 미포함 콘텐츠 검색 (최신순 정렬)
+    @Query("SELECT c FROM Contents c " +
+            "WHERE LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "AND c.status = :status " +
+            "AND c.series IS NULL " +
+            "ORDER BY c.createdDate DESC")
+    List<Contents> searchLatest(@Param("searchWord") String searchWord, @Param("status") Status status,
+            Pageable pageable);
+
+}

--- a/modules/domain/src/main/java/com/ott/domain/contents/repository/ContentsRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/contents/repository/ContentsRepository.java
@@ -12,13 +12,13 @@ import com.ott.domain.contents.domain.Contents;
 
 public interface ContentsRepository extends JpaRepository<Contents, Long> {
 
-    // 제목에 검색어 포함, 상태 ACTIVE, 시리즈 미포함 콘텐츠 검색 (최신순 정렬)
-    @Query("SELECT c FROM Contents c " +
-            "WHERE LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
-            "AND c.status = :status " +
-            "AND c.series IS NULL " +
-            "ORDER BY c.createdDate DESC")
-    List<Contents> searchLatest(@Param("searchWord") String searchWord, @Param("status") Status status,
-            Pageable pageable);
+        // 제목에 검색어 포함, 상태 ACTIVE, 시리즈 없는 콘텐츠만 검색 (최신순 정렬)
+        @Query("SELECT c FROM Contents c " +
+                        "WHERE LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+                        "AND c.status = :status " +
+                        "AND c.series IS NULL " +
+                        "ORDER BY c.createdDate DESC")
+        List<Contents> searchLatest(@Param("keyword") String searchWord, @Param("status") Status status,
+                        Pageable pageable);
 
 }

--- a/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepository.java
@@ -1,0 +1,21 @@
+package com.ott.domain.series.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ott.domain.common.Status;
+import com.ott.domain.series.domain.Series;
+
+public interface SeriesRepository extends JpaRepository<Series, Long> {
+    @Query("SELECT s FROM Series s " +
+            "WHERE LOWER(s.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "AND s.status = :status " +
+            "ORDER BY s.createdDate DESC")
+    List<Series> searchLatest(@Param("keyword") String keyword,
+            @Param("status") Status status,
+            Pageable pageable);
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 콘텐츠(단편)와 시리즈 테이블을 통합하여 검색하는 API 구현
- [x] 키워드 일치 된 데이터들을 **최신순 정렬(CreatedAt)** 을 기준으로 제공함.
- [x] 콘텐츠가 특정 시리즈의 에피소드인 경우, 검색 결과에서 제외(즉, 단편+ 시리즈만 노출)
- [x] 스웨거 및 Postman 을 통한 API 명세 및 동작 확인

### 주요 기술적 고민 

**1. DB 페이징 대신 In-memory 정렬 선택**
Contents 와 Series 는 서로 다른 테이블인데
이 테이블에서 각각 Page 를 통해 각각 size 만큼 가지고 오게 되면
콘텐츠와 시리즈가 합산된 결과에서 각각의 최신순 정렬을 통해
항상 [콘,콘,콘,콘,콘/ 시, 시, 시, 시 ,시] 형태로 
 콘텐츠끼리의 시간순 정렬, 시리즈끼리의 시간순 정렬로 콘- 시 순서가 고정되는 문제가 발생함.

하지만 우리가 원하는 결과는 콘텐츠 시리즈 상관없이 키워드 일치 + 최신순 정렬이기 때문에
위와 같은 문제를 해결하기 위해 각 Repository 에서 
페이징된 결과가 아닌  **리스트 형태**로 먼저 데이터를 가져온 뒤
이후 서비스 레이어에서 데이터 통합 및 정렬을 Stream 을 통해 구현함. (자바 메모리안에서의 Pageing 처리)

**2. 메모리 부하 방지를 위한 데이터 조회 개수 제한**
JPA 에서 Page 를 쓰지 않고 List 로 전체 데이터를 가져오는 방식을 택했기 때문에
콘텐츠 데이터의 양이 많아질 수록 OOM 문제가 발생할 수 있음.
따라서 이를 방지하기 위해 
- 검색어 수를 2글자 이상으로 제한하였고(한 글자는 조회 x)
- 쿼리에 Limit 을 걸어 최대 100개까지만 가져오도록 함.


**3. 수동 페이징 처리**
Page 를 사용하지 않았기 때문에 프론트엔드가 요청한 Page 에 맞게
리스트를 SubList 로 잘라서 수동 페이징 처리를 구현하였음.
- 프론트의 무한스크롤 구현 방식에 맞춰 오프셋으로 구현(커서 방식은 아직 도입하지 않음)



### 📷 스크린샷
**Postman 테스트 스크린샷**
<img width="1039" height="764" alt="image" src="https://github.com/user-attachments/assets/40978486-04e9-4328-9ad4-396e53164717" />


**테스트 결과**
```
{
    "success": true,
    "data": {
        "pageInfo": {
            "currentPage": 0,
            "totalPage": 1,
            "pageSize": 24
        },
        "dataList": [
            {
                "type": "CONTENTS",
                "id": 1,
                "title": "비밀의 언덕",
                "posterUrl": "https://img.com/c1.jpg"
            },
            {
                "type": "SERIES",
                "id": 3,
                "title": "비밀의 문",
                "posterUrl": "https://img.com/s3.jpg"
            },
            {
                "type": "CONTENTS",
                "id": 2,
                "title": "비밀은 없다",
                "posterUrl": "https://img.com/c2.jpg"
            },
            {
                "type": "SERIES",
                "id": 2,
                "title": "비밀의 숲 시즌2",
                "posterUrl": "https://img.com/s2.jpg"
            },
            {
                "type": "SERIES",
                "id": 1,
                "title": "비밀의 숲 시즌1",
                "posterUrl": "https://img.com/s1.jpg"
            }
        ]
    }
}
```



### 추후 고도화 계획(Querydsl 도입 대신 Native SQL 사용)
현재는 두 개의 테이블에서 통합 정렬을 위해 각 테이블에서 제한된 개수만큼 조회한 뒤,
자바 애플리케이션 레벨에서 병합과 정렬하는 방식을 사용하고 있다.

다만 데이터의 규모가 증가할 경우 OOM 문제가 발생할 수 있어서
Querydsl 의 도입하여 두 테이블을 UNION 처리를 하거나 동적 쿼리를 도입할 계획이었으나
찾아보니 Querydsl 은  서로 다른 테이블 간의 UNION 연산을 직접 지원하지 않는다.....
따라서 Native SQL 이나 DB view 를 활용해서 리팩토링하도록 하겠다.
- 바지 사장이 맞았을라나 싶은 생각이....
- 근데 컨텐츠 개수가 1만개 이상을 넘어갈 일은 없어서 자바 메모리에 심각한 부하를 줄 확률은 낮다고 판단했기 때문에 지금은 오버엔지니어링을 피하고 현재와 같은 코드를 작성하였음.


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [ x] 테스트는 잘 통과했나요?
- [ x] 충돌을 해결했나요?
- [ x] 이슈는 등록했나요?
- [ x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) #30 


## 💬 리뷰 요구사항
> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 통합 검색 API 및 검색 엔드포인트 추가
  * 콘텐츠·시리즈를 합친 검색 결과와 페이징 지원
  * 검색 결과 항목에 타입, 아이디, 제목, 포스터 정보 포함

* **개선사항**
  * 검색어 최소 길이(2자) 유효성 및 관련 오류 코드 추가
  * CORS 설정 보완 및 데이터베이스 헬스체크 안정성 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->