### PR TITLE
[OT-68][REFACTOR]: 시리즈 목록 조회 분기 처리 제거

### DIFF
--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/service/BackOfficeSeriesService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/service/BackOfficeSeriesService.java
@@ -36,12 +36,10 @@ public class BackOfficeSeriesService {
 
     @Transactional(readOnly = true)
     public PageResponse<SeriesListResponse> getSeries(int page, int size, String searchWord) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
+        Pageable pageable = PageRequest.of(page, size);
 
         // 1. keyword 유무에 따라 분기 / 시리즈 대상 페이징
-        Page<Series> seriesPage = StringUtils.hasText(searchWord)
-                ? seriesRepository.findByTitleContaining(searchWord, pageable)
-                : seriesRepository.findAll(pageable);
+        Page<Series> seriesPage = seriesRepository.findSeriesList(pageable, searchWord);
 
         // 2. 조회된 시리즈 ID 목록 추출
         List<Long> seriesIdList = seriesPage.getContent().stream()

--- a/modules/common-web/src/main/java/com/ott/common/web/exception/ErrorCode.java
+++ b/modules/common-web/src/main/java/com/ott/common/web/exception/ErrorCode.java
@@ -44,7 +44,7 @@ public enum ErrorCode {
     // ========== Business (B) - 비즈니스 ==========
     CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "콘텐츠를 찾을 수 없습니다"),
     SERIES_NOT_FOUND(HttpStatus.NOT_FOUND, "B002", "시리즈를 찾을 수 없습니다"),
-    SEARCH_KEYWORD_TOO_SHORT(HttpStatus.BAD_REQUEST, "B003", "검색어는 최소 2글자 이상이어야 합니다");
+    SEARCH_KEYWORD_TOO_SHORT(HttpStatus.BAD_REQUEST, "B003", "검색어는 최소 2글자 이상이어야 합니다"),
     INVALID_ROLE_CHANGE(HttpStatus.BAD_REQUEST, "B004", "허용되지 않는 역할 변경입니다")
 
 

--- a/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepository.java
@@ -2,7 +2,6 @@ package com.ott.domain.series.repository;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,16 +10,14 @@ import org.springframework.data.repository.query.Param;
 import com.ott.domain.common.Status;
 import com.ott.domain.series.domain.Series;
 
-public interface SeriesRepository extends JpaRepository<Series, Long> {
-
-        Page<Series> findByTitleContaining(String keyword, Pageable pageable);
+public interface SeriesRepository extends JpaRepository<Series, Long>, SeriesRepositoryCustom {
 
         // 제목에 검색어 포함, 상태 ACTIVE인 시리즈 검색 (최신순 정렬)
         @Query("SELECT s FROM Series s " +
-                        "WHERE LOWER(s.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
-                        "AND s.status = :status " +
-                        "ORDER BY s.createdDate DESC")
+                "WHERE LOWER(s.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+                "AND s.status = :status " +
+                "ORDER BY s.createdDate DESC")
         List<Series> searchLatest(@Param("keyword") String keyword,
-                        @Param("status") Status status,
-                        Pageable pageable);
+                                  @Param("status") Status status,
+                                  Pageable pageable);
 }

--- a/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepositoryCustom.java
+++ b/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.ott.domain.series.repository;
+
+import com.ott.domain.series.domain.Series;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface SeriesRepositoryCustom {
+
+    Page<Series> findSeriesList(Pageable pageable, String keyword);
+}

--- a/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.ott.domain.series.repository;
+
+import com.ott.domain.series.domain.Series;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static com.ott.domain.series.domain.QSeries.series;
+
+@RequiredArgsConstructor
+public class SeriesRepositoryImpl implements SeriesRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Series> findSeriesList(Pageable pageable, String searchWord) {
+        List<Series> seriesList = queryFactory
+                .selectFrom(series)
+                .where(titleContains(searchWord))
+                .orderBy(series.createdDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(series.count())
+                .from(series)
+                .where(titleContains(searchWord));
+
+        return PageableExecutionUtils.getPage(seriesList, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression titleContains(String searchWord) {
+        if (StringUtils.hasText(searchWord))
+            return series.title.contains(searchWord);
+        return null;
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 시리즈 목록 조회 동적 쿼리로 수정
- [x] 에러 코드 중복 제거

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #33 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

1. 백오피스 회원 목록 조회처럼 시리즈 목록 조회도 동적 쿼리가 필요해서 적용했습니다.
2. 다른 작업의 커밋과 겹쳐서 ErrorCode가 중복되는 지점이 있었는데, 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 시리즈 검색 기능의 성능이 개선되었습니다.

* **Refactor**
  * 시리즈 검색 및 조회 로직이 재구성되었습니다.
  * 검색 결과 처리 방식이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->