### PR TITLE
[OT-86][REFACTOR]: ERD 수정에 따른 백오피스 시리즈 관리 페이지 API 변경

### DIFF
--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/controller/BackOfficeSeriesApi.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/controller/BackOfficeSeriesApi.java
@@ -61,6 +61,6 @@ public interface BackOfficeSeriesApi {
             )
     })
     ResponseEntity<SuccessResponse<SeriesDetailResponse>> getSeriesDetail(
-            @Parameter(description = "시리즈 ID", required = true, example = "1") @PathVariable Long seriesId
+            @Parameter(description = "미디어 ID", required = true, example = "1") @PathVariable Long mediaId
     );
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/controller/BackOfficeSeriesController.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/controller/BackOfficeSeriesController.java
@@ -29,10 +29,10 @@ public class BackOfficeSeriesController implements BackOfficeSeriesApi {
     }
 
     @Override
-    @GetMapping("/admin/series/{seriesId}")
-    public ResponseEntity<SuccessResponse<SeriesDetailResponse>> getSeriesDetail(@PathVariable("seriesId") Long seriesId) {
+    @GetMapping("/admin/series/{mediaId}")
+    public ResponseEntity<SuccessResponse<SeriesDetailResponse>> getSeriesDetail(@PathVariable("mediaId") Long mediaId) {
         return ResponseEntity.ok(
-                SuccessResponse.of(backOfficeSeriesService.getSeriesDetail(seriesId))
+                SuccessResponse.of(backOfficeSeriesService.getSeriesDetail(mediaId))
         );
     }
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/controller/BackOfficeSeriesController.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/controller/BackOfficeSeriesController.java
@@ -1,38 +1,38 @@
-//package com.ott.api_admin.series.controller;
-//
-//import com.ott.api_admin.series.dto.response.SeriesDetailResponse;
-//import com.ott.api_admin.series.dto.response.SeriesListResponse;
-//import com.ott.api_admin.series.service.BackOfficeSeriesService;
-//import com.ott.common.web.response.PageResponse;
-//import com.ott.common.web.response.SuccessResponse;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.*;
-//
-//@RestController
-//@RequestMapping("/back-office")
-//@RequiredArgsConstructor
-//public class BackOfficeSeriesController implements BackOfficeSeriesApi {
-//
-//    private final BackOfficeSeriesService backOfficeSeriesService;
-//
-//    @Override
-//    @GetMapping("/admin/series")
-//    public ResponseEntity<SuccessResponse<PageResponse<SeriesListResponse>>> getSeries(
-//            @RequestParam(value = "page", defaultValue = "0") Integer page,
-//            @RequestParam(value = "size", defaultValue = "10") Integer size,
-//            @RequestParam(value = "searchWord", required = false) String searchWord
-//    ) {
-//        return ResponseEntity.ok(
-//                SuccessResponse.of(backOfficeSeriesService.getSeries(page, size, searchWord))
-//        );
-//    }
-//
-//    @Override
-//    @GetMapping("/admin/series/{seriesId}")
-//    public ResponseEntity<SuccessResponse<SeriesDetailResponse>> getSeriesDetail(@PathVariable("seriesId") Long seriesId) {
-//        return ResponseEntity.ok(
-//                SuccessResponse.of(backOfficeSeriesService.getSeriesDetail(seriesId))
-//        );
-//    }
-//}
+package com.ott.api_admin.series.controller;
+
+import com.ott.api_admin.series.dto.response.SeriesDetailResponse;
+import com.ott.api_admin.series.dto.response.SeriesListResponse;
+import com.ott.api_admin.series.service.BackOfficeSeriesService;
+import com.ott.common.web.response.PageResponse;
+import com.ott.common.web.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/back-office")
+@RequiredArgsConstructor
+public class BackOfficeSeriesController implements BackOfficeSeriesApi {
+
+    private final BackOfficeSeriesService backOfficeSeriesService;
+
+    @Override
+    @GetMapping("/admin/series")
+    public ResponseEntity<SuccessResponse<PageResponse<SeriesListResponse>>> getSeries(
+            @RequestParam(value = "page", defaultValue = "0") Integer page,
+            @RequestParam(value = "size", defaultValue = "10") Integer size,
+            @RequestParam(value = "searchWord", required = false) String searchWord
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.of(backOfficeSeriesService.getSeries(page, size, searchWord))
+        );
+    }
+
+    @Override
+    @GetMapping("/admin/series/{seriesId}")
+    public ResponseEntity<SuccessResponse<SeriesDetailResponse>> getSeriesDetail(@PathVariable("seriesId") Long seriesId) {
+        return ResponseEntity.ok(
+                SuccessResponse.of(backOfficeSeriesService.getSeriesDetail(seriesId))
+        );
+    }
+}

--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/dto/response/SeriesListResponse.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/dto/response/SeriesListResponse.java
@@ -8,8 +8,8 @@ import java.util.List;
 @Schema(description = "시리즈 목록 조회 응답")
 public record SeriesListResponse(
 
-        @Schema(type = "Long", description = "시리즈 ID", example = "1")
-        Long seriesId,
+        @Schema(type = "Long", description = "미디어 ID (시리즈에서 참조)", example = "1")
+        Long mediaId,
 
         @Schema(type = "String", description = "썸네일 URL", example = "https://cdn.example.com/thumbnail.jpg")
         String thumbnailUrl,

--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/mapper/BackOfficeSeriesMapper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/mapper/BackOfficeSeriesMapper.java
@@ -26,24 +26,24 @@ public class BackOfficeSeriesMapper {
         );
     }
 
-//    public SeriesDetailResponse toSeriesDetailResponse(Series series, List<SeriesTag> seriesTagList) {
-//        String categoryName = extractCategoryName(seriesTagList);
-//        List<String> tagNameList = extractTagNameList(seriesTagList);
-//
-//        return new SeriesDetailResponse(
-//                series.getId(),
-//                series.getTitle(),
-//                series.getDescription(),
-//                categoryName,
-//                tagNameList,
-//                series.getPublicStatus(),
-//                series.getUploader().getNickname(),
-//                series.getBookmarkCount(),
-//                series.getActors(),
-//                series.getPosterUrl(),
-//                series.getThumbnailUrl()
-//        );
-//    }
+    public SeriesDetailResponse toSeriesDetailResponse(Series series, Media media, String uploaderName, List<MediaTag> mediaTagList) {
+        String categoryName = extractCategoryName(mediaTagList);
+        List<String> tagNameList = extractTagNameList(mediaTagList);
+
+        return new SeriesDetailResponse(
+                series.getId(),
+                media.getTitle(),
+                media.getDescription(),
+                categoryName,
+                tagNameList,
+                media.getPublicStatus(),
+                uploaderName,
+                media.getBookmarkCount(),
+                series.getActors(),
+                media.getPosterUrl(),
+                media.getThumbnailUrl()
+        );
+    }
 
     private String extractCategoryName(List<MediaTag> mediaTagList) {
         return mediaTagList.stream()

--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/mapper/BackOfficeSeriesMapper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/mapper/BackOfficeSeriesMapper.java
@@ -1,30 +1,31 @@
-//package com.ott.api_admin.series.mapper;
-//
-//import com.ott.api_admin.series.dto.response.SeriesDetailResponse;
-//import com.ott.api_admin.series.dto.response.SeriesListResponse;
-//import com.ott.domain.series.domain.Series;
-//import com.ott.domain.series_tag.domain.SeriesTag;
-//import org.springframework.stereotype.Component;
-//
-//import java.util.List;
-//
-//@Component
-//public class BackOfficeSeriesMapper {
-//
-//    public SeriesListResponse toSeriesListResponse(Series series, List<SeriesTag> seriesTagList) {
-//        String categoryName = extractCategoryName(seriesTagList);
-//        List<String> tagNameList = extractTagNameList(seriesTagList);
-//
-//        return new SeriesListResponse(
-//                series.getId(),
-//                series.getThumbnailUrl(),
-//                series.getTitle(),
-//                categoryName,
-//                tagNameList,
-//                series.getPublicStatus()
-//        );
-//    }
-//
+package com.ott.api_admin.series.mapper;
+
+import com.ott.api_admin.series.dto.response.SeriesDetailResponse;
+import com.ott.api_admin.series.dto.response.SeriesListResponse;
+import com.ott.domain.media.domain.Media;
+import com.ott.domain.media_tag.domain.MediaTag;
+import com.ott.domain.series.domain.Series;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class BackOfficeSeriesMapper {
+
+    public SeriesListResponse toSeriesListResponse(Media media, List<MediaTag> mediaTagList) {
+        String categoryName = extractCategoryName(mediaTagList);
+        List<String> tagNameList = extractTagNameList(mediaTagList);
+
+        return new SeriesListResponse(
+                media.getId(),
+                media.getThumbnailUrl(),
+                media.getTitle(),
+                categoryName,
+                tagNameList,
+                media.getPublicStatus()
+        );
+    }
+
 //    public SeriesDetailResponse toSeriesDetailResponse(Series series, List<SeriesTag> seriesTagList) {
 //        String categoryName = extractCategoryName(seriesTagList);
 //        List<String> tagNameList = extractTagNameList(seriesTagList);
@@ -43,17 +44,17 @@
 //                series.getThumbnailUrl()
 //        );
 //    }
-//
-//    private String extractCategoryName(List<SeriesTag> seriesTagList) {
-//        return seriesTagList.stream()
-//                .findFirst()
-//                .map(st -> st.getTag().getCategory().getName())
-//                .orElse(null);
-//    }
-//
-//    private List<String> extractTagNameList(List<SeriesTag> seriesTagList) {
-//        return seriesTagList.stream()
-//                .map(st -> st.getTag().getName())
-//                .toList();
-//    }
-//}
+
+    private String extractCategoryName(List<MediaTag> mediaTagList) {
+        return mediaTagList.stream()
+                .findFirst()
+                .map(mt -> mt.getTag().getCategory().getName())
+                .orElse(null);
+    }
+
+    private List<String> extractTagNameList(List<MediaTag> mediaTagList) {
+        return mediaTagList.stream()
+                .map(mt -> mt.getTag().getName())
+                .toList();
+    }
+}

--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/service/BackOfficeSeriesService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/service/BackOfficeSeriesService.java
@@ -13,6 +13,7 @@ import com.ott.domain.media_tag.repository.MediaTagRepository;
 import com.ott.common.web.response.PageInfo;
 import com.ott.common.web.response.PageResponse;
 import com.ott.domain.series.domain.Series;
+import com.ott.domain.series.repository.SeriesRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -33,6 +34,7 @@ public class BackOfficeSeriesService {
 
     private final MediaRepository mediaRepository;
     private final MediaTagRepository mediaTagRepository;
+    private final SeriesRepository seriesRepository;
 
     @Transactional(readOnly = true)
     public PageResponse<SeriesListResponse> getSeries(int page, int size, String searchWord) {
@@ -67,14 +69,18 @@ public class BackOfficeSeriesService {
         return PageResponse.toPageResponse(pageInfo, responseList);
     }
 
-//    @Transactional(readOnly = true)
-//    public SeriesDetailResponse getSeriesDetail(Long seriesId) {
-//        Series series = seriesRepository.findById(seriesId)
-//                .orElseThrow(() -> new BusinessException(ErrorCode.SERIES_NOT_FOUND));
-//
-//        List<SeriesTag> seriesTagList = seriesTagRepository
-//                .findWithTagAndCategoryBySeriesIds(List.of(seriesId));
-//
-//        return backOfficeSeriesMapper.toSeriesDetailResponse(series, seriesTagList);
-//    }
+    @Transactional(readOnly = true)
+    public SeriesDetailResponse getSeriesDetail(Long mediaId) {
+        // 1. Series + Media + Uploader 한 번에 조회
+        Series series = seriesRepository.findWithMediaAndUploaderByMediaId(mediaId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SERIES_NOT_FOUND));
+
+        Media media = series.getMedia();
+        String uploaderNickname = media.getUploader().getNickname();
+
+        // 2. 태그 조회
+        List<MediaTag> mediaTagList = mediaTagRepository.findWithTagAndCategoryByMediaId(mediaId);
+
+        return backOfficeSeriesMapper.toSeriesDetailResponse(series, media, uploaderNickname, mediaTagList);
+    }
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/service/BackOfficeSeriesService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/service/BackOfficeSeriesService.java
@@ -1,72 +1,72 @@
-//package com.ott.api_admin.series.service;
-//
-//import com.ott.api_admin.series.dto.response.SeriesDetailResponse;
-//import com.ott.api_admin.series.dto.response.SeriesListResponse;
-//import com.ott.api_admin.series.mapper.BackOfficeSeriesMapper;
-//import com.ott.common.web.exception.BusinessException;
-//import com.ott.common.web.exception.ErrorCode;
-//import com.ott.domain.series.repository.SeriesRepository;
-//import com.ott.domain.series_tag.repository.SeriesTagRepository;
-//import com.ott.common.web.response.PageInfo;
-//import com.ott.common.web.response.PageResponse;
-//import com.ott.domain.series.domain.Series;
-//import com.ott.domain.series_tag.domain.SeriesTag;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.data.domain.Page;
-//import org.springframework.data.domain.PageRequest;
-//import org.springframework.data.domain.Pageable;
-//import org.springframework.data.domain.Sort;
-//import org.springframework.stereotype.Service;
-//import org.springframework.transaction.annotation.Transactional;
-//import org.springframework.util.StringUtils;
-//
-//import java.util.Collections;
-//import java.util.List;
-//import java.util.Map;
-//import java.util.stream.Collectors;
-//
-//@RequiredArgsConstructor
-//@Service
-//public class BackOfficeSeriesService {
-//
-//    private final BackOfficeSeriesMapper backOfficeSeriesMapper;
-//
-//    private final SeriesRepository seriesRepository;
-//    private final SeriesTagRepository seriesTagRepository;
-//
-//    @Transactional(readOnly = true)
-//    public PageResponse<SeriesListResponse> getSeries(int page, int size, String searchWord) {
-//        Pageable pageable = PageRequest.of(page, size);
-//
-//        // 1. keyword 유무에 따라 분기 / 시리즈 대상 페이징
-//        Page<Series> seriesPage = seriesRepository.findSeriesList(pageable, searchWord);
-//
-//        // 2. 조회된 시리즈 ID 목록 추출
-//        List<Long> seriesIdList = seriesPage.getContent().stream()
-//                .map(Series::getId)
-//                .toList();
-//
-//        // 3. IN절로 태그 일괄 조회
-//        Map<Long, List<SeriesTag>> tagListBySeriesId = seriesIdList.isEmpty()
-//                ? Collections.emptyMap()
-//                : seriesTagRepository.findWithTagAndCategoryBySeriesIds(seriesIdList).stream()
-//                .collect(Collectors.groupingBy(st -> st.getSeries().getId()));
-//
-//        List<SeriesListResponse> responseList = seriesPage.getContent().stream()
-//                .map(series -> backOfficeSeriesMapper.toSeriesListResponse(
-//                        series,
-//                        tagListBySeriesId.getOrDefault(series.getId(), List.of())
-//                ))
-//                .toList();
-//
-//        PageInfo pageInfo = PageInfo.toPageInfo(
-//                seriesPage.getNumber(),
-//                seriesPage.getTotalPages(),
-//                seriesPage.getSize()
-//        );
-//        return PageResponse.toPageResponse(pageInfo, responseList);
-//    }
-//
+package com.ott.api_admin.series.service;
+
+import com.ott.api_admin.series.dto.response.SeriesDetailResponse;
+import com.ott.api_admin.series.dto.response.SeriesListResponse;
+import com.ott.api_admin.series.mapper.BackOfficeSeriesMapper;
+import com.ott.common.web.exception.BusinessException;
+import com.ott.common.web.exception.ErrorCode;
+import com.ott.domain.common.MediaType;
+import com.ott.domain.media.domain.Media;
+import com.ott.domain.media.repository.MediaRepository;
+import com.ott.domain.media_tag.domain.MediaTag;
+import com.ott.domain.media_tag.repository.MediaTagRepository;
+import com.ott.common.web.response.PageInfo;
+import com.ott.common.web.response.PageResponse;
+import com.ott.domain.series.domain.Series;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class BackOfficeSeriesService {
+
+    private final BackOfficeSeriesMapper backOfficeSeriesMapper;
+
+    private final MediaRepository mediaRepository;
+    private final MediaTagRepository mediaTagRepository;
+
+    @Transactional(readOnly = true)
+    public PageResponse<SeriesListResponse> getSeries(int page, int size, String searchWord) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        // 1. 미디어 중 시리즈 대상 페이징
+        Page<Media> mediaPage = mediaRepository.findMediaListByMediaType(pageable, MediaType.SERIES, searchWord);
+
+        // 2. 조회된 미디어 ID 목록 추출
+        List<Long> mediaIdList = mediaPage.getContent().stream()
+                .map(Media::getId)
+                .toList();
+
+        // 3. IN절로 태그 일괄 조회
+        Map<Long, List<MediaTag>> tagListByMediaId = mediaIdList.isEmpty()
+                ? Collections.emptyMap()
+                : mediaTagRepository.findWithTagAndCategoryByMediaIds(mediaIdList).stream()
+                .collect(Collectors.groupingBy(mt -> mt.getMedia().getId()));
+
+        List<SeriesListResponse> responseList = mediaPage.getContent().stream()
+                .map(media -> backOfficeSeriesMapper.toSeriesListResponse(
+                        media,
+                        tagListByMediaId.getOrDefault(media.getId(), List.of())
+                ))
+                .toList();
+
+        PageInfo pageInfo = PageInfo.toPageInfo(
+                mediaPage.getNumber(),
+                mediaPage.getTotalPages(),
+                mediaPage.getSize()
+        );
+        return PageResponse.toPageResponse(pageInfo, responseList);
+    }
+
 //    @Transactional(readOnly = true)
 //    public SeriesDetailResponse getSeriesDetail(Long seriesId) {
 //        Series series = seriesRepository.findById(seriesId)
@@ -77,4 +77,4 @@
 //
 //        return backOfficeSeriesMapper.toSeriesDetailResponse(series, seriesTagList);
 //    }
-//}
+}

--- a/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepository.java
@@ -1,0 +1,7 @@
+package com.ott.domain.media.repository;
+
+import com.ott.domain.media.domain.Media;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MediaRepository extends JpaRepository<Media, Long>, MediaRepositoryCustom {
+}

--- a/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryCustom.java
+++ b/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.ott.domain.media.repository;
+
+public interface MediaRepositoryCustom {
+}

--- a/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryCustom.java
+++ b/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryCustom.java
@@ -1,4 +1,11 @@
 package com.ott.domain.media.repository;
 
+import com.ott.domain.common.MediaType;
+import com.ott.domain.media.domain.Media;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface MediaRepositoryCustom {
+
+    Page<Media> findMediaListByMediaType(Pageable pageable, MediaType mediaType, String searchWord);
 }

--- a/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryImpl.java
@@ -1,0 +1,10 @@
+package com.ott.domain.media.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MediaRepositoryImpl implements MediaRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+}

--- a/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryImpl.java
@@ -1,10 +1,52 @@
 package com.ott.domain.media.repository;
 
+import com.ott.domain.common.MediaType;
+import com.ott.domain.media.domain.Media;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static com.ott.domain.media.domain.QMedia.media;
 
 @RequiredArgsConstructor
 public class MediaRepositoryImpl implements MediaRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Media> findMediaListByMediaType(Pageable pageable, MediaType mediaType, String searchWord) {
+        List<Media> mediaList = queryFactory
+                .selectFrom(media)
+                .where(
+                        media.mediaType.eq(mediaType),
+                        titleContains(searchWord)
+                )
+                .orderBy(media.createdDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(media.count())
+                .from(media)
+                .where(
+                        media.mediaType.eq(mediaType),
+                        titleContains(searchWord)
+                );
+
+        return PageableExecutionUtils.getPage(mediaList, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression titleContains(String searchWord) {
+        if (StringUtils.hasText(searchWord))
+            return media.title.contains(searchWord);
+        return null;
+    }
 }

--- a/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepository.java
@@ -1,0 +1,7 @@
+package com.ott.domain.media_tag.repository;
+
+import com.ott.domain.media_tag.domain.MediaTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MediaTagRepository extends JpaRepository<MediaTag, Long>, MediaTagRepositoryCustom {
+}

--- a/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepositoryCustom.java
+++ b/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepositoryCustom.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface MediaTagRepositoryCustom {
 
     List<MediaTag> findWithTagAndCategoryByMediaIds(List<Long> mediaIds);
+
+    List<MediaTag> findWithTagAndCategoryByMediaId(Long mediaId);
 }

--- a/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepositoryCustom.java
+++ b/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.ott.domain.media_tag.repository;
+
+public interface MediaTagRepositoryCustom {
+}

--- a/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepositoryCustom.java
+++ b/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepositoryCustom.java
@@ -1,4 +1,10 @@
 package com.ott.domain.media_tag.repository;
 
+import com.ott.domain.media_tag.domain.MediaTag;
+
+import java.util.List;
+
 public interface MediaTagRepositoryCustom {
+
+    List<MediaTag> findWithTagAndCategoryByMediaIds(List<Long> mediaIds);
 }

--- a/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepositoryImpl.java
@@ -24,4 +24,14 @@ public class MediaTagRepositoryImpl implements MediaTagRepositoryCustom {
                 .where(mediaTag.media.id.in(mediaIds))
                 .fetch();
     }
+
+    @Override
+    public List<MediaTag> findWithTagAndCategoryByMediaId(Long mediaId) {
+        return queryFactory
+                .selectFrom(mediaTag)
+                .join(mediaTag.tag, tag).fetchJoin()
+                .join(tag.category, category).fetchJoin()
+                .where(mediaTag.media.id.eq(mediaId))
+                .fetch();
+    }
 }

--- a/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepositoryImpl.java
@@ -1,10 +1,27 @@
 package com.ott.domain.media_tag.repository;
 
+import com.ott.domain.media_tag.domain.MediaTag;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.ott.domain.media_tag.domain.QMediaTag.mediaTag;
+import static com.ott.domain.tag.domain.QTag.tag;
+import static com.ott.domain.category.domain.QCategory.category;
 
 @RequiredArgsConstructor
 public class MediaTagRepositoryImpl implements MediaTagRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MediaTag> findWithTagAndCategoryByMediaIds(List<Long> mediaIds) {
+        return queryFactory
+                .selectFrom(mediaTag)
+                .join(mediaTag.tag, tag).fetchJoin()
+                .join(tag.category, category).fetchJoin()
+                .where(mediaTag.media.id.in(mediaIds))
+                .fetch();
+    }
 }

--- a/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/media_tag/repository/MediaTagRepositoryImpl.java
@@ -1,0 +1,10 @@
+package com.ott.domain.media_tag.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MediaTagRepositoryImpl implements MediaTagRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+}

--- a/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepository.java
@@ -12,12 +12,12 @@ import com.ott.domain.series.domain.Series;
 
 public interface SeriesRepository extends JpaRepository<Series, Long>, SeriesRepositoryCustom {
 
-        // 제목에 검색어 포함, 상태 ACTIVE인 시리즈 검색 (최신순 정렬)
-        @Query("SELECT s FROM Series s " +
-                "WHERE LOWER(s.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
-                "AND s.status = :status " +
-                "ORDER BY s.createdDate DESC")
-        List<Series> searchLatest(@Param("keyword") String keyword,
-                                  @Param("status") Status status,
-                                  Pageable pageable);
+//        // 제목에 검색어 포함, 상태 ACTIVE인 시리즈 검색 (최신순 정렬)
+//        @Query("SELECT s FROM Series s " +
+//                "WHERE LOWER(s.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+//                "AND s.status = :status " +
+//                "ORDER BY s.createdDate DESC")
+//        List<Series> searchLatest(@Param("keyword") String keyword,
+//                                  @Param("status") Status status,
+//                                  Pageable pageable);
 }

--- a/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepository.java
@@ -1,23 +1,23 @@
-//package com.ott.domain.series.repository;
-//
-//import java.util.List;
-//
-//import org.springframework.data.domain.Pageable;
-//import org.springframework.data.jpa.repository.JpaRepository;
-//import org.springframework.data.jpa.repository.Query;
-//import org.springframework.data.repository.query.Param;
-//
-//import com.ott.domain.common.Status;
-//import com.ott.domain.series.domain.Series;
-//
-//public interface SeriesRepository extends JpaRepository<Series, Long>, SeriesRepositoryCustom {
-//
-//        // 제목에 검색어 포함, 상태 ACTIVE인 시리즈 검색 (최신순 정렬)
-//        @Query("SELECT s FROM Series s " +
-//                "WHERE LOWER(s.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
-//                "AND s.status = :status " +
-//                "ORDER BY s.createdDate DESC")
-//        List<Series> searchLatest(@Param("keyword") String keyword,
-//                                  @Param("status") Status status,
-//                                  Pageable pageable);
-//}
+package com.ott.domain.series.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ott.domain.common.Status;
+import com.ott.domain.series.domain.Series;
+
+public interface SeriesRepository extends JpaRepository<Series, Long>, SeriesRepositoryCustom {
+
+        // 제목에 검색어 포함, 상태 ACTIVE인 시리즈 검색 (최신순 정렬)
+        @Query("SELECT s FROM Series s " +
+                "WHERE LOWER(s.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+                "AND s.status = :status " +
+                "ORDER BY s.createdDate DESC")
+        List<Series> searchLatest(@Param("keyword") String keyword,
+                                  @Param("status") Status status,
+                                  Pageable pageable);
+}

--- a/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepositoryCustom.java
+++ b/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepositoryCustom.java
@@ -1,10 +1,10 @@
 package com.ott.domain.series.repository;
 
 import com.ott.domain.series.domain.Series;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
 
 public interface SeriesRepositoryCustom {
 
-    Page<Series> findSeriesList(Pageable pageable, String keyword);
+    Optional<Series> findWithMediaAndUploaderByMediaId(Long mediaId);
 }

--- a/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepositoryImpl.java
@@ -1,45 +1,29 @@
-//package com.ott.domain.series.repository;
-//
-//import com.ott.domain.series.domain.Series;
-//import com.querydsl.core.types.dsl.BooleanExpression;
-//import com.querydsl.jpa.impl.JPAQuery;
-//import com.querydsl.jpa.impl.JPAQueryFactory;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.data.domain.Page;
-//import org.springframework.data.domain.Pageable;
-//import org.springframework.data.support.PageableExecutionUtils;
-//import org.springframework.util.StringUtils;
-//
-//import java.util.List;
-//
-//import static com.ott.domain.series.domain.QSeries.series;
-//
-//@RequiredArgsConstructor
-//public class SeriesRepositoryImpl implements SeriesRepositoryCustom {
-//
-//    private final JPAQueryFactory queryFactory;
-//
-//    @Override
-//    public Page<Series> findSeriesList(Pageable pageable, String searchWord) {
-//        List<Series> seriesList = queryFactory
-//                .selectFrom(series)
-//                .where(titleContains(searchWord))
-//                .orderBy(series.createdDate.desc())
-//                .offset(pageable.getOffset())
-//                .limit(pageable.getPageSize())
-//                .fetch();
-//
-//        JPAQuery<Long> countQuery = queryFactory
-//                .select(series.count())
-//                .from(series)
-//                .where(titleContains(searchWord));
-//
-//        return PageableExecutionUtils.getPage(seriesList, pageable, countQuery::fetchOne);
-//    }
-//
-//    private BooleanExpression titleContains(String searchWord) {
-//        if (StringUtils.hasText(searchWord))
-//            return series.title.contains(searchWord);
-//        return null;
-//    }
-//}
+package com.ott.domain.series.repository;
+
+import com.ott.domain.series.domain.Series;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.ott.domain.media.domain.QMedia.media;
+import static com.ott.domain.member.domain.QMember.member;
+import static com.ott.domain.series.domain.QSeries.series;
+
+@RequiredArgsConstructor
+public class SeriesRepositoryImpl implements SeriesRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Series> findWithMediaAndUploaderByMediaId(Long mediaId) {
+        Series result = queryFactory
+                .selectFrom(series)
+                .join(series.media, media).fetchJoin()
+                .join(media.uploader, member).fetchJoin()
+                .where(media.id.eq(mediaId))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 시리즈 목록 조회 (검색 포함)
- [x] 시리즈 상세 조회

### 📷 스크린샷

**[시리즈 목록 조회]**
<img width="1252" height="1316" alt="image" src="https://github.com/user-attachments/assets/7593000b-37da-45d1-8844-5fe480e7149c" />

**[시리즈 상세 조회]**
<img width="1228" height="1050" alt="image" src="https://github.com/user-attachments/assets/8da53fa6-454f-4723-89d7-cc3da465c5cd" />

## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #46 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

시리즈 관리 페이지 API 수정했습니다.
**[공통]**
목록 조회, 상세 조회 모두 mediaId를 반환합니다.

1. 시리즈 목록 조회 시에 각 시리즈의 **mediaId**를 반환합니다. 이를 통해 상세 조회 시 사용합니다.
2. 시리즈 상세 조회 시에는 mediaId를 사용하여 시리즈, 태그를 한 번에 조회합니다.

https://github.com/OpenTheTaste/backend/pull/31
위 PR에서의 수정 사항 반영입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Refactor**
  * 시리즈 상세 조회 API의 경로 매개변수명이 `seriesId`에서 `mediaId`로 변경되었습니다.
  * 시리즈 목록 응답의 필드명이 `seriesId`에서 `mediaId`로 변경되었습니다.
  * 백엔드 데이터 접근 계층을 재구성하여 안정성과 성능을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->