### PR TITLE
[OT-169][BUILD]: ALB가 보내는 요청 https 변환

### DIFF
--- a/apps/api-admin/src/main/resources/application.yml
+++ b/apps/api-admin/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 server:
   port: 8081
+  forward-headers-strategy: framework
 
 spring:
   datasource:

--- a/apps/api-user/src/main/resources/application.yml
+++ b/apps/api-user/src/main/resources/application.yml
@@ -1,8 +1,9 @@
 app:
-  frontend-url: ${FRONTEND_URL:http://localhost:8080}
+  frontend-url: ${FRONTEND_URL}
 
 server:
   port: 8080
+  forward-headers-strategy: framework # ALB가 보내는 https 신호를 스프링이 신뢰하여 springdoc이 OpenAPI 서버 URL을 https://...로 생성
 
 spring:
   datasource:


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- 문제점
배포 환경에서 ALB로 내려온 요청(https)를 스프링이 신뢰하지 못하여 http로 반환하는 이슈 발생

- 해결
yml파일 설정을 통해 리버스 포릭시 헤더  신뢰 설정을 함
`
server:
  port: 8081
  forward-headers-strategy: framework
`


### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [ ] 테스트는 잘 통과했나요?
- [ ] 충돌을 해결했나요?
- [ ] 이슈는 등록했나요?
- [ ] 라벨은 등록했나요?


## #️⃣ 연관된 이슈


## 💬 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 로드 밸런서로부터 전달되는 헤더를 올바르게 처리하도록 개선되었습니다.
* OpenAPI 서버 URL이 HTTPS 프로토콜로 정확하게 생성됩니다.
* 프론트엔드 URL 설정이 환경 변수를 통해 관리되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->