### PR TITLE
[OT-208][FEAT]: 백오피스 카테고리별 태그 목록 조회 추가

### DIFF
--- a/apps/api-admin/src/main/java/com/ott/api_admin/tag/controller/BackOfficeTagApi.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/tag/controller/BackOfficeTagApi.java
@@ -1,5 +1,6 @@
 package com.ott.api_admin.tag.controller;
 
+import com.ott.api_admin.tag.dto.response.TagResponse;
 import com.ott.api_admin.tag.dto.response.TagViewResponse;
 import com.ott.common.web.exception.ErrorResponse;
 import com.ott.common.web.response.SuccessResponse;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -33,5 +35,20 @@ public interface BackOfficeTagApi {
     })
     ResponseEntity<SuccessResponse<List<TagViewResponse>>> getTagViewStats(
             @Parameter(description = "카테고리 ID", required = true) @PathVariable(value = "categoryId") Long categoryId
+    );
+
+    @Operation(summary = "카테고리별 태그 목록 조회", description = "특정 카테고리에 속한 태그 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "카테고리별 태그 목록 조회 성공",
+                    content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = TagResponse.class)))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "카테고리별 태그 목록 조회 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
+    ResponseEntity<SuccessResponse<List<TagResponse>>> getTagListByCategory(
+            @Positive @Parameter(description = "카테고리 ID", example = "1") Long categoryId
     );
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/tag/controller/BackOfficeTagApi.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/tag/controller/BackOfficeTagApi.java
@@ -49,6 +49,6 @@ public interface BackOfficeTagApi {
             )
     })
     ResponseEntity<SuccessResponse<List<TagResponse>>> getTagListByCategory(
-            @Positive @Parameter(description = "카테고리 ID", example = "1") Long categoryId
+            @Parameter(description = "카테고리 ID", example = "1") @PathVariable(value = "categoryId") Long categoryId
     );
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/tag/controller/BackOfficeTagController.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/tag/controller/BackOfficeTagController.java
@@ -1,5 +1,6 @@
 package com.ott.api_admin.tag.controller;
 
+import com.ott.api_admin.tag.dto.response.TagResponse;
 import com.ott.api_admin.tag.dto.response.TagViewResponse;
 import com.ott.api_admin.tag.service.BackOfficeTagService;
 import com.ott.common.web.response.SuccessResponse;
@@ -23,6 +24,16 @@ public class BackOfficeTagController implements BackOfficeTagApi {
     ) {
         return ResponseEntity.ok(
                 SuccessResponse.of(backOfficeTagService.getTagViewStats(categoryId))
+        );
+    }
+
+    @Override
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<SuccessResponse<List<TagResponse>>> getTagListByCategory(
+            @PathVariable(value = "categoryId") Long categoryId
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.of(backOfficeTagService.getTagListByCategory(categoryId))
         );
     }
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/tag/dto/response/TagResponse.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/tag/dto/response/TagResponse.java
@@ -1,0 +1,14 @@
+package com.ott.api_admin.tag.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카테고리별 태그 목록 응답")
+public record TagResponse(
+
+        @Schema(type = "Long", example = "1", description = "태그 ID")
+        Long tagId,
+
+        @Schema(type = "String", example = "로맨스", description = "태그명")
+        String name
+) {
+}

--- a/apps/api-admin/src/main/java/com/ott/api_admin/tag/mapper/BackOfficeTagMapper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/tag/mapper/BackOfficeTagMapper.java
@@ -1,8 +1,12 @@
 package com.ott.api_admin.tag.mapper;
 
+import com.ott.api_admin.tag.dto.response.TagResponse;
 import com.ott.api_admin.tag.dto.response.TagViewResponse;
+import com.ott.domain.tag.domain.Tag;
 import com.ott.domain.watch_history.repository.TagViewCountProjection;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class BackOfficeTagMapper {
@@ -11,6 +15,13 @@ public class BackOfficeTagMapper {
         return new TagViewResponse(
                 projection.tagName(),
                 projection.viewCount()
+        );
+    }
+
+    public TagResponse toTagResponse(Tag tag) {
+        return new TagResponse(
+                tag.getId(),
+                tag.getName()
         );
     }
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/tag/service/BackOfficeTagService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/tag/service/BackOfficeTagService.java
@@ -30,6 +30,10 @@ public class BackOfficeTagService {
 
     @Transactional(readOnly = true)
     public List<TagViewResponse> getTagViewStats(Long categoryId) {
+        boolean exist = categoryRepository.existsById(categoryId);
+        if (!exist)
+            throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
+
         LocalDateTime startDate = LocalDate.now().withDayOfMonth(1).atStartOfDay();
         LocalDateTime endDate = startDate.plusMonths(1);
 

--- a/apps/api-admin/src/main/java/com/ott/api_admin/tag/service/BackOfficeTagService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/tag/service/BackOfficeTagService.java
@@ -1,7 +1,14 @@
 package com.ott.api_admin.tag.service;
 
+import com.ott.api_admin.tag.dto.response.TagResponse;
 import com.ott.api_admin.tag.dto.response.TagViewResponse;
 import com.ott.api_admin.tag.mapper.BackOfficeTagMapper;
+import com.ott.common.web.exception.BusinessException;
+import com.ott.common.web.exception.ErrorCode;
+import com.ott.domain.category.domain.Category;
+import com.ott.domain.category.repository.CategoryRepository;
+import com.ott.domain.tag.domain.Tag;
+import com.ott.domain.tag.repository.TagRepository;
 import com.ott.domain.watch_history.repository.WatchHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +23,10 @@ import java.util.List;
 public class BackOfficeTagService {
 
     private final BackOfficeTagMapper backOfficeTagMapper;
+
     private final WatchHistoryRepository watchHistoryRepository;
+    private final CategoryRepository categoryRepository;
+    private final TagRepository tagRepository;
 
     @Transactional(readOnly = true)
     public List<TagViewResponse> getTagViewStats(Long categoryId) {
@@ -26,6 +36,16 @@ public class BackOfficeTagService {
         return watchHistoryRepository.countByTagAndCategoryIdAndWatchedBetween(categoryId, startDate, endDate)
                 .stream()
                 .map(backOfficeTagMapper::toTagViewResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TagResponse> getTagListByCategory(Long categoryId) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        return tagRepository.findAllByCategory(category).stream()
+                .map(backOfficeTagMapper::toTagResponse)
                 .toList();
     }
 }

--- a/modules/domain/src/main/java/com/ott/domain/tag/repository/TagRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/tag/repository/TagRepository.java
@@ -35,4 +35,6 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
 
     // ACTIVE한 특정 태그 조회
    Optional<Tag> findByIdAndStatus(Long tagId, Status status);
+
+    List<Tag> findAllByCategory(Category category);
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 백오피스 카테고리별 태그 목록 조회 API 추가 
- [x] 카테고리별 태그 당월 시청 통계 조회 시 카테고리 검증 추가

### 📷 스크린샷

콘텐츠 업로드 시 태그 선택 부분입니다!
**[화면]**
<img width="713" height="1323" alt="image" src="https://github.com/user-attachments/assets/d29a8a9f-bc6b-4d14-88d1-5e8cc35002a9" />

**[응답]**
<img width="986" height="981" alt="image" src="https://github.com/user-attachments/assets/9715793e-b994-4a14-8868-0f424766e3e1" />


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #114 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

1. 프론트엔드에서 요청한 누락된 API 개발입니다.
2. 콘텐츠 업로드 시 드롭다운으로 표시되며, 양이 적기 때문에 페이징은 필요 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 카테고리별 태그 목록 조회용 신규 백오피스 API 추가 (GET /back-office/admin/tags/{categoryId})
  * 태그 ID와 태그명을 포함하는 구조화된 응답 형식 추가

* **Improvements**
  * 존재하지 않는 카테고리 요청에 대한 검증 및 명확한 오류 응답 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->