### PR TITLE
[OT-219] [CHORE]: Access Token 만료 시간 변경

### DIFF
--- a/apps/api-admin/src/main/resources/application.yml
+++ b/apps/api-admin/src/main/resources/application.yml
@@ -39,7 +39,7 @@ management:
 # JWT 설정
 jwt:
   secret: ${JWT_SECRET_BASE64}
-  access-token-expiry: 3200000     # 60분
+  access-token-expiry: 3600000     # 60분
   refresh-token-expiry: 1209600000 # 14일
 
 springdoc:

--- a/apps/api-admin/src/main/resources/application.yml
+++ b/apps/api-admin/src/main/resources/application.yml
@@ -39,7 +39,7 @@ management:
 # JWT 설정
 jwt:
   secret: ${JWT_SECRET_BASE64}
-  access-token-expiry: 1800000     # 30분
+  access-token-expiry: 3200000     # 60분
   refresh-token-expiry: 1209600000 # 14일
 
 springdoc:

--- a/apps/api-admin/src/main/resources/application.yml
+++ b/apps/api-admin/src/main/resources/application.yml
@@ -39,7 +39,7 @@ management:
 # JWT 설정
 jwt:
   secret: ${JWT_SECRET_BASE64}
-  access-token-expiry: 60000       # 1분
+  access-token-expiry: 1800000     # 30분
   refresh-token-expiry: 1209600000 # 14일
 
 springdoc:

--- a/apps/api-user/src/main/resources/application.yml
+++ b/apps/api-user/src/main/resources/application.yml
@@ -66,7 +66,7 @@ management:
 # JWT 설정
 jwt:
   secret: ${JWT_SECRET_BASE64:}
-  access-token-expiry: 60000       # 1분
+  access-token-expiry: 1800000       # 30분
   refresh-token-expiry: 1209600000   # 14일
 
 springdoc:


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] Access Token 만료 시간 변경

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #118 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

프론트엔드 Reissue 작업이 마무리되어 Access Token 만료 시간을 1분 -> 30분으로 변경했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 관리용 서비스의 JWT 액세스 토큰 만료 시간을 기존 1분에서 약 60분으로 연장.
  * 사용자용 서비스의 JWT 액세스 토큰 만료 시간을 기존 1분에서 30분으로 연장.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->