### PR TITLE
[OT-217][FIX]: 콘텐츠 상세 MediaId 통일 및 댓글 소유권 필드 추가

### DIFF
--- a/apps/api-user/src/main/java/com/ott/api_user/comment/controller/CommentApi.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/comment/controller/CommentApi.java
@@ -124,6 +124,7 @@ public interface CommentApi {
                         @Parameter(description = "미디어 ID", required = true, example = "10") @PathVariable("mediaId") Long contentsId,
                         @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(value = "page", defaultValue = "0") Integer page,
                         @Parameter(description = "페이지 크기", example = "20") @RequestParam(value = "size", defaultValue = "20") Integer size,
-                        @Parameter(description = "스포일러 포함 여부 (true: 전체 조회, false: 스포 제외)", example = "false") @RequestParam(value = "includeSpoiler", defaultValue = "false") boolean includeSpoiler);
+                        @Parameter(description = "스포일러 포함 여부 (true: 전체 조회, false: 스포 제외)", example = "false") @RequestParam(value = "includeSpoiler", defaultValue = "false") boolean includeSpoiler,
+                        @AuthenticationPrincipal @Parameter(hidden = true) Long memberId);
 
 }

--- a/apps/api-user/src/main/java/com/ott/api_user/comment/controller/CommentApi.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/comment/controller/CommentApi.java
@@ -119,9 +119,9 @@ public interface CommentApi {
                         @ApiResponse(responseCode = "404", description = "콘텐츠를 찾을 수 없음", content = {
                                         @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)) })
         })
-        @GetMapping("/{contentsId}/comments")
+        @GetMapping("/{mediaId}/comments")
         ResponseEntity<SuccessResponse<PageResponse<ContentsCommentResponse>>> getContentCommentsList(
-                        @Parameter(description = "콘텐츠 ID", required = true, example = "10") @PathVariable("contentsId") Long contentsId,
+                        @Parameter(description = "미디어 ID", required = true, example = "10") @PathVariable("mediaId") Long contentsId,
                         @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(value = "page", defaultValue = "0") Integer page,
                         @Parameter(description = "페이지 크기", example = "20") @RequestParam(value = "size", defaultValue = "20") Integer size,
                         @Parameter(description = "스포일러 포함 여부 (true: 전체 조회, false: 스포 제외)", example = "false") @RequestParam(value = "includeSpoiler", defaultValue = "false") boolean includeSpoiler);

--- a/apps/api-user/src/main/java/com/ott/api_user/comment/controller/CommentController.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/comment/controller/CommentController.java
@@ -66,14 +66,15 @@ public class CommentController implements CommentApi {
         return ResponseEntity.ok(SuccessResponse.of(commentService.getMyComments(memberId, page, size)));
     }
 
+    // 콘텐츠 상세 페이지의 댓글 목록 조회
     @Override
     public ResponseEntity<SuccessResponse<PageResponse<ContentsCommentResponse>>> getContentCommentsList(
-            @PathVariable(value = "contentsId") Long contentsId,
+            @PathVariable(value = "mediaId") Long mediaId,
             @RequestParam(value = "page", defaultValue = "0") Integer pageParam,
             @RequestParam(value = "size", defaultValue = "20")  Integer sizeParam,
             @RequestParam(value = "includeSpoiler", defaultValue = "false") boolean includeSpoiler) {
         return ResponseEntity.ok(
-                SuccessResponse.of(commentService.getContentsCommentList(contentsId, pageParam,
+                SuccessResponse.of(commentService.getContentsCommentList(mediaId, pageParam,
                         sizeParam, includeSpoiler)));
 
     }

--- a/apps/api-user/src/main/java/com/ott/api_user/comment/controller/CommentController.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/comment/controller/CommentController.java
@@ -72,9 +72,10 @@ public class CommentController implements CommentApi {
             @PathVariable(value = "mediaId") Long mediaId,
             @RequestParam(value = "page", defaultValue = "0") Integer pageParam,
             @RequestParam(value = "size", defaultValue = "20")  Integer sizeParam,
-            @RequestParam(value = "includeSpoiler", defaultValue = "false") boolean includeSpoiler) {
+            @RequestParam(value = "includeSpoiler", defaultValue = "false") boolean includeSpoiler,
+            @AuthenticationPrincipal Long memberId) {
         return ResponseEntity.ok(
-                SuccessResponse.of(commentService.getContentsCommentList(mediaId, pageParam,
+                SuccessResponse.of(commentService.getContentsCommentList(mediaId, memberId, pageParam,
                         sizeParam, includeSpoiler)));
 
     }

--- a/apps/api-user/src/main/java/com/ott/api_user/comment/dto/response/ContentsCommentResponse.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/comment/dto/response/ContentsCommentResponse.java
@@ -14,28 +14,32 @@ import lombok.Getter;
 @AllArgsConstructor
 @Schema(description = "댓글 조회 응답 DTO")
 public class ContentsCommentResponse {
-    @Schema(description = "댓글 고유 ID", example = "1")
+    @Schema(type = "Long", description = "댓글 고유 ID", example = "1")
     private Long commentId;
 
-    @Schema(description = "작성자 닉네임", example = "영화광문어")
+    @Schema(type = "String", description = "작성자 닉네임", example = "영화광문어")
     private String nickname;
 
-    @Schema(description = "댓글 내용", example = "이 영화 진짜 시간 가는 줄 모르고 봤네요!! 강추합니다.")
+    @Schema(type = "String", description = "댓글 내용", example = "이 영화 진짜 시간 가는 줄 모르고 봤네요!! 강추합니다.")
     private String content;
 
-    @Schema(description = "스포일러 여부", example = "true")
-    private boolean isSpoiler;
+    @Schema(type = "Boolean", description = "스포일러 여부", example = "true")
+    private Boolean isSpoiler;
 
-    @Schema(description = "작성 일시")
+    @Schema(type = "LocalDateTime", description = "작성 일시")
     private LocalDateTime createdAt;
 
-    public static ContentsCommentResponse from(Comment comment) {
+    @Schema(type = "Boolean", description = "본인 댓글 여부(수정/삭제 버튼 노출용)", example = "ture")
+    private Boolean isMine;
+
+    public static ContentsCommentResponse from(Comment comment, Boolean isMine) {
         return ContentsCommentResponse.builder()
                 .commentId(comment.getId())
                 .nickname(comment.getMember().getNickname())
                 .content(comment.getContent())
                 .isSpoiler(comment.getIsSpoiler())
                 .createdAt(comment.getCreatedDate())
+                .isMine(isMine)
                 .build();
     }
 }

--- a/apps/api-user/src/main/java/com/ott/api_user/comment/dto/response/ContentsCommentResponse.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/comment/dto/response/ContentsCommentResponse.java
@@ -24,15 +24,15 @@ public class ContentsCommentResponse {
     private String content;
 
     @Schema(type = "Boolean", description = "스포일러 여부", example = "true")
-    private Boolean isSpoiler;
+    private boolean isSpoiler;
 
     @Schema(type = "LocalDateTime", description = "작성 일시")
     private LocalDateTime createdAt;
 
-    @Schema(type = "Boolean", description = "본인 댓글 여부(수정/삭제 버튼 노출용)", example = "ture")
-    private Boolean isMine;
+    @Schema(type = "Boolean", description = "본인 댓글 여부(수정/삭제 버튼 노출용)", example = "true")
+    private boolean isMine;
 
-    public static ContentsCommentResponse from(Comment comment, Boolean isMine) {
+    public static ContentsCommentResponse from(Comment comment, boolean isMine) {
         return ContentsCommentResponse.builder()
                 .commentId(comment.getId())
                 .nickname(comment.getMember().getNickname())

--- a/apps/api-user/src/main/java/com/ott/api_user/comment/service/CommentService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/comment/service/CommentService.java
@@ -11,6 +11,7 @@ import com.ott.common.web.response.PageInfo;
 import com.ott.common.web.response.PageResponse;
 import com.ott.domain.comment.domain.Comment;
 import com.ott.domain.comment.repository.CommentRepository;
+import com.ott.domain.common.PublicStatus;
 import com.ott.domain.common.Status;
 import com.ott.domain.contents.domain.Contents;
 import com.ott.domain.contents.repository.ContentsRepository;
@@ -117,16 +118,17 @@ public class CommentService {
                 return PageResponse.toPageResponse(pageInfo, responseList);
         }
         
+        // 콘텐츠 상세 조회 댓글 목록
         @Transactional(readOnly = true)
-        public PageResponse<ContentsCommentResponse> getContentsCommentList(Long contentsId, int page, int size, boolean includeSpoiler) {
+        public PageResponse<ContentsCommentResponse> getContentsCommentList(Long mediaId, int page, int size, boolean includeSpoiler) {
 
-                if (!contentsRepository.existsByIdAndStatus(contentsId, Status.ACTIVE)) {
-                throw new BusinessException(ErrorCode.CONTENTS_NOT_FOUND);
-                }
+                // mediaId를 기준으로 Contents 엔티티 조회
+                Contents contents = contentsRepository.findByMediaIdAndStatusAndMedia_PublicStatus(mediaId, Status.ACTIVE, PublicStatus.PUBLIC)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
 
                 Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
 
-                Page<Comment> commentPage = commentRepository.findByContents_IdAndStatusWithSpoilerCondition(contentsId, Status.ACTIVE, includeSpoiler, pageable);
+                Page<Comment> commentPage = commentRepository.findByContents_IdAndStatusWithSpoilerCondition(contents.getId(), Status.ACTIVE, includeSpoiler, pageable);
 
                 List<ContentsCommentResponse> responseList = commentPage.getContent().stream()
                         .map(ContentsCommentResponse::from)

--- a/apps/api-user/src/main/java/com/ott/api_user/comment/service/CommentService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/comment/service/CommentService.java
@@ -120,7 +120,7 @@ public class CommentService {
         
         // 콘텐츠 상세 조회 댓글 목록
         @Transactional(readOnly = true)
-        public PageResponse<ContentsCommentResponse> getContentsCommentList(Long mediaId, int page, int size, boolean includeSpoiler) {
+        public PageResponse<ContentsCommentResponse> getContentsCommentList(Long mediaId, Long memberId, int page, int size, boolean includeSpoiler) {
 
                 // mediaId를 기준으로 Contents 엔티티 조회
                 Contents contents = contentsRepository.findByMediaIdAndStatusAndMedia_PublicStatus(mediaId, Status.ACTIVE, PublicStatus.PUBLIC)
@@ -131,8 +131,14 @@ public class CommentService {
                 Page<Comment> commentPage = commentRepository.findByContents_IdAndStatusWithSpoilerCondition(contents.getId(), Status.ACTIVE, includeSpoiler, pageable);
 
                 List<ContentsCommentResponse> responseList = commentPage.getContent().stream()
-                        .map(ContentsCommentResponse::from)
-                        .collect(Collectors.toList());
+                        .map(comment -> {
+                                // 유저 ID가 댓글 작성자의 ID와 같다면 true
+                                Boolean isMine = isCommentOwner(comment, memberId);
+                                
+                                // 수정된 DTO의 of 메서드 사용
+                                return ContentsCommentResponse.from(comment, isMine);
+                        })
+                        .toList();
 
                 PageInfo pageInfo = PageInfo.toPageInfo(
                         commentPage.getNumber(),
@@ -140,5 +146,12 @@ public class CommentService {
                         commentPage.getSize());
 
                 return PageResponse.toPageResponse(pageInfo, responseList);
+        }
+
+        private boolean isCommentOwner(Comment comment, Long currentMemberId) {
+                if (currentMemberId == null) {
+                        return false;
+                }
+                return comment.getMember().getId().equals(currentMemberId);
         }
 }

--- a/apps/api-user/src/main/java/com/ott/api_user/comment/service/CommentService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/comment/service/CommentService.java
@@ -150,7 +150,7 @@ public class CommentService {
 
         private boolean isCommentOwner(Comment comment, Long currentMemberId) {
                 if (currentMemberId == null) {
-                        return false;
+                        throw new BusinessException(ErrorCode.USER_NOT_FOUND);
                 }
                 return comment.getMember().getId().equals(currentMemberId);
         }

--- a/apps/api-user/src/main/java/com/ott/api_user/content/dto/ContentsDetailResponse.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/content/dto/ContentsDetailResponse.java
@@ -38,10 +38,10 @@ public class ContentsDetailResponse {
     @Schema(description = "태그 목록", example = "드라마, 범죄, 수사")
     private List<String> tags;
 
-    @Schema(description = "사용자 북마크 여부", example = "true")
+    @Schema(description = "사용자 북마크 여부(seriesMediaId 에 대한 여부)", example = "true")
     private Boolean isBookmarked;
 
-    @Schema(description = "사용자 좋아요 여부", example = "true")
+    @Schema(description = "사용자 좋아요 여부(seriesMediaId 에 대한 여부)", example = "true")
     private Boolean isLiked;
 
     @Schema(description = "마스터 재생목록 URL(HLS)", example = "https://example.com/master.m3u8")

--- a/apps/api-user/src/main/java/com/ott/api_user/content/dto/ContentsDetailResponse.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/content/dto/ContentsDetailResponse.java
@@ -15,9 +15,9 @@ import lombok.Getter;
 @Schema(description = "컨텐츠 상세(재생) 조회 응답 DTO")
 public class ContentsDetailResponse {
     @Schema(description = "미디어 고유 ID", example = "1")
-    private Long id;
+    private Long mediaId;
 
-    @Schema(description = "시리즈 본체의 미디어 ID (단편이면 null)", example = "101")
+    @Schema(description = "해당 미디어의 시리즈ID (본체 미디어 ID) (단편이면 null)", example = "101")
     private Long seriesMediaId;
 
 
@@ -60,12 +60,13 @@ public class ContentsDetailResponse {
             Integer positionSec) {
 
         Long seriesMediaId = null;
+
         if (contents.getSeries() != null && contents.getSeries().getMedia() != null) {
             seriesMediaId = contents.getSeries().getMedia().getId();
         }
 
         return ContentsDetailResponse.builder()
-                .id(contents.getMedia().getId())
+                .mediaId(contents.getMedia().getId())
                 .seriesMediaId(seriesMediaId) 
                 .title(contents.getMedia().getTitle())
                 .description(contents.getMedia().getDescription())

--- a/apps/api-user/src/main/java/com/ott/api_user/content/dto/ContentsDetailResponse.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/content/dto/ContentsDetailResponse.java
@@ -20,7 +20,6 @@ public class ContentsDetailResponse {
     @Schema(description = "해당 미디어의 시리즈ID (본체 미디어 ID) (단편이면 null)", example = "101")
     private Long seriesMediaId;
 
-
     @Schema(description = "콘텐츠 제목", example = "비밀의 숲")
     private String title;
 

--- a/apps/api-user/src/main/java/com/ott/api_user/content/service/ContentsService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/content/service/ContentsService.java
@@ -36,14 +36,21 @@ public class ContentsService {
         
         // 재생 상세
         public ContentsDetailResponse getContentDetail(Long mediaId, Long memberId) {
+                
                 Contents contents = contentsRepository.findByMediaIdAndStatusAndMedia_PublicStatus(mediaId, Status.ACTIVE, PublicStatus.PUBLIC)
                                 .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
+
+                // 북마크, 좋아요 종속을 위한 컨텐츠의 본체 MediaID 찾기 (단편이라면 본인 MediaId 그대로 반환)
+                Long targetMediaId = (contents.getSeries() != null && contents.getSeries().getMedia() != null)
+                                ? contents.getSeries().getMedia().getId()
+                                : mediaId;
+
 
                 List<String> tags = tagRepository.findTagNamesByMediaId(mediaId, Status.ACTIVE);
                 List<String> categories = categoryRepository.findCategoryNamesByMediaId(mediaId, Status.ACTIVE);
 
-                Boolean isBookmarked = bookmarkRepository.existsByMemberIdAndMediaIdAndStatus(memberId, mediaId,Status.ACTIVE);
-                Boolean isLiked = likesRepository.existsByMemberIdAndMediaIdAndStatus(memberId, mediaId, Status.ACTIVE);
+                Boolean isBookmarked = bookmarkRepository.existsByMemberIdAndMediaIdAndStatus(memberId, targetMediaId, Status.ACTIVE);
+                Boolean isLiked = likesRepository.existsByMemberIdAndMediaIdAndStatus(memberId, targetMediaId, Status.ACTIVE);
 
                 //  이어보기 지점 조회
                 Integer positionSec = playbackRepository.findByMemberIdAndMediaId(memberId, mediaId)

--- a/apps/api-user/src/main/java/com/ott/api_user/content/service/ContentsService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/content/service/ContentsService.java
@@ -41,9 +41,15 @@ public class ContentsService {
                                 .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
 
                 // 북마크, 좋아요 종속을 위한 컨텐츠의 본체 MediaID 찾기 (단편이라면 본인 MediaId 그대로 반환)
-                Long targetMediaId = (contents.getSeries() != null && contents.getSeries().getMedia() != null)
-                                ? contents.getSeries().getMedia().getId()
-                                : mediaId;
+                Long targetMediaId = mediaId;
+
+                if (contents.getSeries() != null) {
+                        if (contents.getSeries().getMedia() == null) {
+                                // 시리즈 데이터는 있는데 부모 미디어가 없을 떄 - 데이터 정합성 오류 보장
+                                throw new BusinessException(ErrorCode.MEDIA_NOT_FOUND); 
+                        }
+                        targetMediaId = contents.getSeries().getMedia().getId();
+                }
 
 
                 List<String> tags = tagRepository.findTagNamesByMediaId(mediaId, Status.ACTIVE);

--- a/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlayListAPI.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlayListAPI.java
@@ -32,7 +32,7 @@ import java.util.List;
 @SecurityRequirement(name = "BearerAuth") // 인증인가 확인
 @Tag(name = "Playlist", description = "플레이리스트& 재생목록 API, excludeId 는 재생목록 API 호출 시에만 포함시킵니다")
 @ApiResponses(value = {
-    @ApiResponse(responseCode = "200", description = "플레이리스트 조회 성공- 응답 구성", 
+    @ApiResponse(responseCode = "0", description = "플레이리스트 조회 성공- 응답 구성", 
         content = @Content(schema = @Schema(implementation = PlaylistResponse.class))),
     @ApiResponse(responseCode = "200", description = "조회 성공", 
         content = @Content(mediaType = "application/json", schema = @Schema(implementation = PageResponse.class))),
@@ -56,9 +56,8 @@ public interface PlayListAPI {
         
 
         @Operation(summary = "선호 태그 순위별 리스트", description = "유저의 Top 3 태그 순위를 기반으로 제공합니다.")
-        @ApiResponses(
-                @ApiResponse(responseCode = "200", description = "태그 순위별 조회 성공", content = @Content(schema = @Schema(implementation = TopTagPlaylistResponse.class))))
         @GetMapping("/tags/top")
+        @ApiResponse(responseCode = "200", description = "태그별 리스트 조회 성공", content = @Content(schema = @Schema(implementation = TopTagPlaylistResponse.class)))
         ResponseEntity<SuccessResponse<TopTagPlaylistResponse>> getTopTagPlaylists(
                 @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
                 @PositiveOrZero @Max(value = 2, message = "인덱스는 2 이하여야 합니다.") @Parameter(description = "유저 취향 순위 (0, 1, 2)", required = true) @RequestParam(value = "index") Integer index,
@@ -67,13 +66,9 @@ public interface PlayListAPI {
                 @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
         );
 
-        
 
         @Operation(summary = "상세 페이지 - 특정 해시태그 리스트", description = "해당 태그의 영상만 제공합니다.")
-                @ApiResponses({
-                @ApiResponse(responseCode = "200", description = "태그별 리스트 조회 성공", content = @Content(schema = @Schema(implementation = TopTagPlaylistResponse.class))),
-                @ApiResponse(responseCode = "404", description = "해당 태그를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-        })
+        @ApiResponse(responseCode = "404", description = "해당 태그를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         @GetMapping("/tags/{tagId}")
         ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getTagPlaylists(
                 @Parameter(description = "태그 ID", required = true) @PathVariable(value = "tagId") Long tagId,

--- a/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlayListAPI.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlayListAPI.java
@@ -30,127 +30,147 @@ import java.util.List;
 
 @RequestMapping("/playlists")
 @SecurityRequirement(name = "BearerAuth") // 인증인가 확인
-@Tag(name = "Playlist", description = "플레이리스트 API")
+@Tag(name = "Playlist", description = "플레이리스트& 재생목록 API, excludeId 는 재생목록 API 호출 시에만 포함시킵니다")
+@ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "조회 성공", 
+        content = @Content(mediaType = "application/json", schema = @Schema(implementation = PageResponse.class))),
+    @ApiResponse(responseCode = "401", description = "인증 실패", 
+        content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+    @ApiResponse(responseCode = "400", description = "요청 파라미터 오류", 
+        content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+})
 public interface PlayListAPI {
 
-    // -------------------------------------------------------
-    // 태그별 추천 콘텐츠 목록 조회
-    // -------------------------------------------------------
-    @Operation(summary = "[마이페이지] 태그별 추천 콘텐츠 리스트 조회", description = "해당 태그에 속하는 콘텐츠를 최대 20개 반환"
-    )
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200", description = "조회 성공",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = TagPlaylistResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400", description = "요청 파라미터 오류",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "401", description = "인증 실패 (토큰 없음 또는 만료)",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404", description = "회원 또는 태그를 찾을 수 없음",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            )
-    })
-    @GetMapping("/me/{tagId}")
-    ResponseEntity<SuccessResponse<List<TagPlaylistResponse>>> getRecommendContentsByTag(
-            @AuthenticationPrincipal Long memberId,
-            @Positive @PathVariable Long tagId
-    );
+
+        @Operation(summary = "OO 님이 좋아하실만한 콘텐츠", description = "유저 취향을 합산하여 추천합니다. (홈 화면 셔플 지원)")
+        @GetMapping("/recommend")
+        ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getRecommendPlaylists(
+                @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
+                @PositiveOrZero @Parameter(description = "페이지 번호(0부터 시작)", example = "0") @RequestParam(value = "page", defaultValue = "0") Integer page,
+                @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "20") Integer size,
+                @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
+        );
+
+        
+
+        @Operation(summary = "선호 태그 순위별 리스트", description = "유저의 Top 3 태그 순위를 기반으로 제공합니다.")
+        @ApiResponses(
+                @ApiResponse(responseCode = "200", description = "태그 순위별 조회 성공", content = @Content(schema = @Schema(implementation = TopTagPlaylistResponse.class))))
+        @GetMapping("/tags/top")
+        ResponseEntity<SuccessResponse<TopTagPlaylistResponse>> getTopTagPlaylists(
+                @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
+                @PositiveOrZero @Max(value = 2, message = "인덱스는 2 이하여야 합니다.") @Parameter(description = "유저 취향 순위 (0, 1, 2)", required = true) @RequestParam(value = "index") Integer index,
+                @PositiveOrZero @Parameter(description = "페이지 번호") @RequestParam(value = "page", defaultValue = "0") Integer page,
+                @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "20") Integer size,
+                @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
+        );
+
+        
+
+        @Operation(summary = "상세 페이지 - 특정 해시태그 리스트", description = "해당 태그의 영상만 제공합니다.")
+                @ApiResponses({
+                @ApiResponse(responseCode = "200", description = "태그별 리스트 조회 성공", content = @Content(schema = @Schema(implementation = TopTagPlaylistResponse.class))),
+                @ApiResponse(responseCode = "404", description = "해당 태그를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+        })
+        @GetMapping("/tags/{tagId}")
+        ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getTagPlaylists(
+                @Parameter(description = "태그 ID", required = true) @PathVariable(value = "tagId") Long tagId,
+                @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
+                @PositiveOrZero @Parameter(description = "페이지 번호") @RequestParam(value = "page", defaultValue = "0") Integer page,
+                @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "20") Integer size,
+                @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
+        );
+
+        @Operation(summary = "인기 차트 (Trending)", description = "북마크가 많은 인기 순서대로 제공합니다.")
+        @GetMapping("/trending")
+        ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getTrendingPlaylists(
+                @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
+                @PositiveOrZero @Parameter(description = "페이지 번호") @RequestParam(value = "page", defaultValue = "0") Integer page,
+                @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "20") Integer size,
+                @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
+        );
+
+        @Operation(summary = "시청 이력 (History)", description = "유저가 최근 시청한 영상 목록을 제공합니다.")
+        @GetMapping("/history")
+        ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getHistoryPlaylists(
+                @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
+                @PositiveOrZero @Parameter(description = "페이지 번호") @RequestParam(value = "page", defaultValue = "0") Integer page,
+                @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "20") Integer size,
+                @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
+        );
+
+        @Operation(summary = "북마크 목록 (Bookmark)", description = "유저가 북마크한 영상 목록을 제공합니다.")
+        @GetMapping("/bookmarks")
+        ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getBookmarkPlaylists(
+                @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
+                @PositiveOrZero @Parameter(description = "페이지 번호") @RequestParam(value = "page", defaultValue = "0") Integer page,
+                @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "20") Integer size,
+                @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
+        );
+
+        @Operation(summary = "검색 상세 페이지 재생목록", description = "검색 결과에서 진입 시 종합 추천 리스트로 대체하여 제공합니다.")
+        @GetMapping("/search")
+        ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getSearchPlaylists(
+                @Parameter(description = "현재 영상 ID", required = true) @RequestParam(value = "excludeMediaId") Long excludeMediaId,
+                @PositiveOrZero @Parameter(description = "페이지 번호") @RequestParam(value = "page", defaultValue = "0") Integer page,
+                @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "20") Integer size,
+                @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
+        );
 
 
-    // -------------------------------------------------------
-    // 전체 시청이력 플레이리스트 페이징 조회
-    // -------------------------------------------------------
-    @Operation(summary = "[마이페이지] 과거 시청 이력 리스트 조회", description = "전체 시청이력을 최신순으로 10개씩 페이징 조회합니다. 이어보기 시점 포함.")
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200", description = "조회 성공",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = PageResponse.class))),
-            @ApiResponse(
-                    responseCode = "401", description = "인증 실패",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(
-                    responseCode = "404", description = "회원을 찾을 수 없음",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @GetMapping("/me/history")
-    ResponseEntity<SuccessResponse<PageResponse<RecentWatchResponse>>> getWatchHistoryPlaylist(
-            @AuthenticationPrincipal Long memberId,
-            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
-            @PositiveOrZero @RequestParam(defaultValue = "0") Integer page
-    );
+                // -------------------------------------------------------
+        // 태그별 추천 콘텐츠 목록 조회
+        // -------------------------------------------------------
+        //     @Operation(summary = "[마이페이지] 태그별 추천 콘텐츠 리스트 조회", description = "해당 태그에 속하는 콘텐츠를 최대 20개 반환"
+        //     )
+        //     @ApiResponses({
+        //             @ApiResponse(
+        //                     responseCode = "200", description = "조회 성공",
+        //                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = TagPlaylistResponse.class)
+        //                     )
+        //             ),
+        //             @ApiResponse(
+        //                     responseCode = "400", description = "요청 파라미터 오류",
+        //                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)
+        //                     )
+        //             ),
+        //             @ApiResponse(
+        //                     responseCode = "401", description = "인증 실패 (토큰 없음 또는 만료)",
+        //                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)
+        //                     )
+        //             ),
+        //             @ApiResponse(
+        //                     responseCode = "404", description = "회원 또는 태그를 찾을 수 없음",
+        //                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)
+        //                     )
+        //             )
+        //     })
+        //     @GetMapping("/me/{tagId}")
+        //     ResponseEntity<SuccessResponse<List<TagPlaylistResponse>>> getRecommendContentsByTag(
+        //             @AuthenticationPrincipal Long memberId,
+        //             @Positive @PathVariable Long tagId
+        //     );
 
-    @Operation(summary = "OO 님이 좋아하실만한 콘텐츠", description = "유저 취향을 합산하여 추천합니다. (홈 화면 셔플 지원)")
-    @GetMapping("/recommend")
-    ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getRecommendPlaylists(
-            @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
-            @PositiveOrZero @Parameter(description = "페이지 번호(0부터 시작)", example = "0") @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "10") Integer size,
-            @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
-    );
 
-    @Operation(summary = "선호 태그 순위별 리스트", description = "유저의 Top 3 태그 순위를 기반으로 제공합니다.")
-    @GetMapping("/tags/top")
-    ResponseEntity<SuccessResponse<TopTagPlaylistResponse>> getTopTagPlaylists(
-            @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
-            @PositiveOrZero @Max(value = 2, message = "인덱스는 2 이하여야 합니다.") @Parameter(description = "유저 취향 순위 (0, 1, 2)", required = true) @RequestParam(value = "index") Integer index,
-            @PositiveOrZero @Parameter(description = "페이지 번호") @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "10") Integer size,
-            @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
-    );
-
-    @Operation(summary = "상세 페이지 - 특정 해시태그 리스트", description = "해당 태그의 영상만 제공합니다.")
-    @GetMapping("/tags/{tagId}")
-    ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getTagPlaylists(
-            @Parameter(description = "태그 ID", required = true) @PathVariable(value = "tagId") Long tagId,
-            @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
-            @PositiveOrZero @Parameter(description = "페이지 번호") @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "10") Integer size,
-            @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
-    );
-
-    @Operation(summary = "인기 차트 (Trending)", description = "북마크가 많은 인기 순서대로 제공합니다.")
-    @GetMapping("/trending")
-    ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getTrendingPlaylists(
-            @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
-            @PositiveOrZero @Parameter(description = "페이지 번호") @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "10") Integer size,
-            @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
-    );
-
-    @Operation(summary = "시청 이력 (History)", description = "유저가 최근 시청한 영상 목록을 제공합니다.")
-    @GetMapping("/history")
-    ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getHistoryPlaylists(
-            @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
-            @PositiveOrZero @Parameter(description = "페이지 번호") @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "10") Integer size,
-            @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
-    );
-
-    @Operation(summary = "북마크 목록 (Bookmark)", description = "유저가 북마크한 영상 목록을 제공합니다.")
-    @GetMapping("/bookmarks")
-    ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getBookmarkPlaylists(
-            @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
-            @PositiveOrZero @Parameter(description = "페이지 번호") @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "10") Integer size,
-            @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
-    );
-
-    @Operation(summary = "검색 상세 페이지 재생목록", description = "검색 결과에서 진입 시 종합 추천 리스트로 대체하여 제공합니다.")
-    @GetMapping("/search")
-    ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getSearchPlaylists(
-            @Parameter(description = "현재 영상 ID", required = true) @RequestParam(value = "excludeMediaId") Long excludeMediaId,
-            @PositiveOrZero @Parameter(description = "페이지 번호") @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @Positive @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "10") Integer size,
-            @Parameter(hidden = true) @AuthenticationPrincipal Long memberId
-    );
+        // -------------------------------------------------------
+        // 전체 시청이력 플레이리스트 페이징 조회
+        // -------------------------------------------------------
+        //     @Operation(summary = "[마이페이지] 과거 시청 이력 리스트 조회", description = "전체 시청이력을 최신순으로 10개씩 페이징 조회합니다. 이어보기 시점 포함.")
+        //     @ApiResponses({
+        //             @ApiResponse(
+        //                     responseCode = "200", description = "조회 성공",
+        //                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = PageResponse.class))),
+        //             @ApiResponse(
+        //                     responseCode = "401", description = "인증 실패",
+        //                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+        //             @ApiResponse(
+        //                     responseCode = "404", description = "회원을 찾을 수 없음",
+        //                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+        //     })
+        //     @GetMapping("/me/history")
+        //     ResponseEntity<SuccessResponse<PageResponse<RecentWatchResponse>>> getWatchHistoryPlaylist(
+        //             @AuthenticationPrincipal Long memberId,
+        //             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+        //             @PositiveOrZero @RequestParam(defaultValue = "0") Integer page
+        //     );
 }

--- a/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlayListAPI.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlayListAPI.java
@@ -32,6 +32,8 @@ import java.util.List;
 @SecurityRequirement(name = "BearerAuth") // 인증인가 확인
 @Tag(name = "Playlist", description = "플레이리스트& 재생목록 API, excludeId 는 재생목록 API 호출 시에만 포함시킵니다")
 @ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "플레이리스트 조회 성공- 응답 구성", 
+        content = @Content(schema = @Schema(implementation = PlaylistResponse.class))),
     @ApiResponse(responseCode = "200", description = "조회 성공", 
         content = @Content(mediaType = "application/json", schema = @Schema(implementation = PageResponse.class))),
     @ApiResponse(responseCode = "401", description = "인증 실패", 

--- a/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlaylistController.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlaylistController.java
@@ -30,27 +30,6 @@ public class PlaylistController implements PlayListAPI {
     private final PlaylistService playlistService;
     private final PlaylistStrategyService playlisStrategytService;
 
-    // 태그 별 추천 리스트 조회
-    @Override
-    @GetMapping("/me/{tagId}")
-    public ResponseEntity<SuccessResponse<List<TagPlaylistResponse>>> getRecommendContentsByTag(
-            @AuthenticationPrincipal Long memberId,
-            @Positive @PathVariable Long tagId
-    ) {
-        return ResponseEntity.ok(SuccessResponse.of(playlistService.getRecommendContentsByTag(memberId, tagId)));
-    }
-
-
-    // 과거 시청 이력 조회, 10개씩 조회
-    @Override
-    @GetMapping("/me/history")
-    public ResponseEntity<SuccessResponse<PageResponse<RecentWatchResponse>>> getWatchHistoryPlaylist(
-            @AuthenticationPrincipal Long memberId,
-            @PositiveOrZero @RequestParam(defaultValue = "0") Integer page
-    ) {
-        return ResponseEntity.ok(SuccessResponse.of(playlistService.getWatchHistoryPlaylist(memberId, page)));
-
-    }
 
     // 1. 종합 추천
     @Override
@@ -171,6 +150,28 @@ public class PlaylistController implements PlayListAPI {
         return execute(condition, page, size, memberId);
     }
 
+        // // 태그 별 추천 리스트 조회
+    // @Override
+    // @GetMapping("/me/{tagId}")
+    // public ResponseEntity<SuccessResponse<List<TagPlaylistResponse>>> getRecommendContentsByTag(
+    //         @AuthenticationPrincipal Long memberId,
+    //         @Positive @PathVariable Long tagId
+    // ) {
+    //     return ResponseEntity.ok(SuccessResponse.of(playlistService.getRecommendContentsByTag(memberId, tagId)));
+    // }
+
+
+    // // 과거 시청 이력 조회, 10개씩 조회
+    // @Override
+    // @GetMapping("/me/history")
+    // public ResponseEntity<SuccessResponse<PageResponse<RecentWatchResponse>>> getWatchHistoryPlaylist(
+    //         @AuthenticationPrincipal Long memberId,
+    //         @PositiveOrZero @RequestParam(defaultValue = "0") Integer page
+    // ) {
+    //     return ResponseEntity.ok(SuccessResponse.of(playlistService.getWatchHistoryPlaylist(memberId, page)));
+
+    // }
+
 
     // 공통 응답 메서드
     private ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> execute(
@@ -184,5 +185,7 @@ public class PlaylistController implements PlayListAPI {
 
         return ResponseEntity.ok(SuccessResponse.of(playlisStrategytService.getPlaylists(condition, pageable)));
     }
+
+
 }
 

--- a/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlaylistController.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlaylistController.java
@@ -36,7 +36,7 @@ public class PlaylistController implements PlayListAPI {
     public ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getRecommendPlaylists(
             @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
             @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @RequestParam(value = "size", defaultValue = "10") Integer size,
+            @RequestParam(value = "size", defaultValue = "20") Integer size,
             @AuthenticationPrincipal Long memberId) {
 
         PlaylistCondition condition = new PlaylistCondition();
@@ -52,7 +52,7 @@ public class PlaylistController implements PlayListAPI {
             @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
             @RequestParam(value = "index") Integer index,
             @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @RequestParam(value = "size", defaultValue = "10") Integer size,
+            @RequestParam(value = "size", defaultValue = "20") Integer size,
             @AuthenticationPrincipal Long memberId) {
 
         PlaylistCondition condition = new PlaylistCondition();
@@ -76,7 +76,7 @@ public class PlaylistController implements PlayListAPI {
             @PathVariable(value = "tagId") Long tagId,
             @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
             @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @RequestParam(value = "size", defaultValue = "10") Integer size,
+            @RequestParam(value = "size", defaultValue = "20") Integer size,
             @AuthenticationPrincipal Long memberId) {
 
         PlaylistCondition condition = new PlaylistCondition();
@@ -92,7 +92,7 @@ public class PlaylistController implements PlayListAPI {
     public ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getTrendingPlaylists(
             @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
             @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @RequestParam(value = "size", defaultValue = "10") Integer size,
+            @RequestParam(value = "size", defaultValue = "20") Integer size,
             @AuthenticationPrincipal Long memberId) {
 
         PlaylistCondition condition = new PlaylistCondition();
@@ -109,7 +109,7 @@ public class PlaylistController implements PlayListAPI {
     public ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getHistoryPlaylists(
             @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
             @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @RequestParam(value = "size", defaultValue = "10") Integer size,
+            @RequestParam(value = "size", defaultValue = "20") Integer size,
             @AuthenticationPrincipal Long memberId) {
 
         PlaylistCondition condition = new PlaylistCondition();
@@ -124,7 +124,7 @@ public class PlaylistController implements PlayListAPI {
     public ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getBookmarkPlaylists(
             @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
             @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @RequestParam(value = "size", defaultValue = "10") Integer size,
+            @RequestParam(value = "size", defaultValue = "20") Integer size,
             @AuthenticationPrincipal Long memberId) {
 
         PlaylistCondition condition = new PlaylistCondition();
@@ -139,7 +139,7 @@ public class PlaylistController implements PlayListAPI {
     public ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getSearchPlaylists(
             @RequestParam(value = "excludeMediaId") Long excludeMediaId,
             @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @RequestParam(value = "size", defaultValue = "10") Integer size,
+            @RequestParam(value = "size", defaultValue = "20") Integer size,
             @AuthenticationPrincipal Long memberId) {
 
         PlaylistCondition condition = new PlaylistCondition();

--- a/modules/common-security/src/main/java/com/ott/common/security/util/CookieUtil.java
+++ b/modules/common-security/src/main/java/com/ott/common/security/util/CookieUtil.java
@@ -10,7 +10,7 @@ public class CookieUtil {
 
     public void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
-                .domain("openthetaste.cloud")  // 로컬 테스트 시 주석처리!!!
+                //.domain("openthetaste.cloud")  // 로컬 테스트 시 주석처리!!!
                 .httpOnly(true) // JS 접근 차단 -> 크로스 사이트 스크립트 공격 대비
                 .secure(true) // HTTPS 요청만 허용
                 .path("/")  // 모든 경로로 전송
@@ -22,7 +22,7 @@ public class CookieUtil {
 
     public void deleteCookie(HttpServletResponse response, String name) {
         ResponseCookie cookie = ResponseCookie.from(name, "")
-                .domain("openthetaste.cloud") // 로컬 테스트 시 주석처리!!!
+                //.domain("openthetaste.cloud") // 로컬 테스트 시 주석처리!!!
                 .httpOnly(true)
                 .secure(true)
                 .path("/")

--- a/modules/common-security/src/main/java/com/ott/common/security/util/CookieUtil.java
+++ b/modules/common-security/src/main/java/com/ott/common/security/util/CookieUtil.java
@@ -10,7 +10,7 @@ public class CookieUtil {
 
     public void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
-                //.domain("openthetaste.cloud")  // 로컬 테스트 시 주석처리!!!
+                .domain("openthetaste.cloud")  // 로컬 테스트 시 주석처리!!!
                 .httpOnly(true) // JS 접근 차단 -> 크로스 사이트 스크립트 공격 대비
                 .secure(true) // HTTPS 요청만 허용
                 .path("/")  // 모든 경로로 전송
@@ -22,7 +22,7 @@ public class CookieUtil {
 
     public void deleteCookie(HttpServletResponse response, String name) {
         ResponseCookie cookie = ResponseCookie.from(name, "")
-                //.domain("openthetaste.cloud") // 로컬 테스트 시 주석처리!!!
+                .domain("openthetaste.cloud") // 로컬 테스트 시 주석처리!!!
                 .httpOnly(true)
                 .secure(true)
                 .path("/")


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 상세 페이지 댓글 목록 조회 시, 내가 작성한 댓글임을 나타낼 수 있는 fasle/true 를 응답 필드에 포함.  
   - 본인이 작성한 댓글인지 판단할 수 있는 데이터가 없어 프론트에서 수정/삭제 버튼 노출 처리가 불가했음.
   - 프론트의 요청에 맞춰 응답 필드에 isMine 필드를 포함시켜 버튼 노출처리 가능하도록 함.

- [x] 콘텐츠 상세 조회 시 개별 에피에 대한 좋아요/북마크는 시리즈 본체에 대한 좋아요/북마크로 종속 시켜 응답
   -  개별 에피소드(mediaId)를 기준으로 좋아요/북마크 여부를 조회하여, 시리즈 본체에 누른 상태가 반영되지 않았음.
   -  상위 Series 먼저 조회 후 시리즈물일 경우 시리즈 본체의 Media ID(targetMediaId)를 기준으로 좋아요/북마크 상태를 통합하여 응답하도록 개선.
- [x] 댓글 목록 &상세 조회 시 MediaId 로 식별자 통합
   - 프론트에서는 mediaId를 보내는데, 백엔드에서는 contentsId로 단건 조회를 시도하여 404 CONTENTS_NOT_FOUND 예외가 발생한 문제 해결
 

### 📷 스크린샷
<img width="1472" height="567" alt="image" src="https://github.com/user-attachments/assets/ad26d237-2160-4d79-aa38-21dc143fd41f" />


<img width="1362" height="588" alt="image" src="https://github.com/user-attachments/assets/19b25d27-a29e-495d-9aa8-b2daa9fd3da6" />



## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) #117 
closes #117 


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 댓글 응답에 본인여부(isMine) 추가 — 본인 댓글에 편집/삭제 버튼 노출.
  * 플레이리스트 API 확장: 추천/인기/태그별/시청기록/북마크/검색 엔드포인트 추가 및 페이징 기본 size=20.

* **Bug Fixes**
  * 댓글 조회 경로 식별자(mediaId) 정비 및 인증 사용자 기반 소유권 판단 적용.

* **Chores**
  * 쿠키 도메인 적용 설정 활성화.

* **Removed**
  * 일부 레거시 플레이리스트 엔드포인트 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->