### PR TITLE
[OT-223][FIX]: 요청, 응답 media_id 타입 변경

### DIFF
--- a/apps/api-user/src/main/java/com/ott/api_user/comment/dto/request/CreateCommentRequest.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/comment/dto/request/CreateCommentRequest.java
@@ -11,9 +11,9 @@ import lombok.*;
 @Schema(description = "댓글 등록 요청 DTO")
 public class CreateCommentRequest {
 
-    @NotNull(message = "콘텐츠 ID는 필수 입니다.")
-    @Schema(type= "Long", example = "1", description = "콘텐츠 ID")
-    private Long contentId;
+    @NotNull(message = "미디어 ID는 필수 입니다.")
+    @Schema(type= "Long", example = "1", description = "미디어 ID")
+    private Long mediaId;
 
     @NotBlank(message = "댓글 내용은 필수 입니다.")
     @Size(max = 100, message = "댓글은 100자 이내로 입력해주세요.")

--- a/apps/api-user/src/main/java/com/ott/api_user/comment/dto/response/CommentResponse.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/comment/dto/response/CommentResponse.java
@@ -17,8 +17,8 @@ public class CommentResponse {
     @Schema(type = "Long", example = "1", description = "댓글 ID")
     private Long commentId;
 
-    @Schema(type = "Long", example = "5", description = "콘텐츠 ID")
-    private Long contentsId;
+    @Schema(type = "Long", example = "5", description = "미디어 ID")
+    private Long mediaId;
 
     @Schema(type = "String", example = "밤티 하네 ㅋㅋ", description = "댓글 내용")
     private String content;
@@ -35,7 +35,7 @@ public class CommentResponse {
     public static CommentResponse from(Comment comment) {
         return CommentResponse.builder()
                 .commentId(comment.getId())
-                .contentsId(comment.getContents().getId())
+                .mediaId(comment.getContents().getMedia().getId())
                 .content(comment.getContent())
                 .isSpoiler(comment.getIsSpoiler())
                 .createdDate(comment.getCreatedDate())

--- a/apps/api-user/src/main/java/com/ott/api_user/comment/service/CommentService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/comment/service/CommentService.java
@@ -27,7 +27,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -47,10 +46,10 @@ public class CommentService {
                 Member findMember = memberRepository.findById(memberId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-                Contents contents = contentsRepository.findByIdAndStatus(request.getContentId(), Status.ACTIVE)
+                Contents contents = contentsRepository.findByMediaIdAndStatusAndMedia_PublicStatus(
+                                request.getMediaId(), Status.ACTIVE, PublicStatus.PUBLIC)
                         .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
 
-                // 한 유저가 한 콘텐츠에 여러 댓글 허용?
                 Comment saved = commentRepository.save(
                         Comment.builder()
                                 .member(findMember)


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [ ] 댓글 요청, 응답 DTO contents_id -> media_id 변경

### 📷 스크린샷
- 댓글 등록 요청 DTO
 <img width="411" height="282" alt="image" src="https://github.com/user-attachments/assets/07cf2378-3585-4741-a35b-a8a7fe81872d" />

- 댓글 등록 응답 DTO
 <img width="692" height="347" alt="image" src="https://github.com/user-attachments/assets/b97016d2-263e-4a8d-af6c-8591a81b8e9c" />



## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
close #122 


## 💬 리뷰 요구사항
간단한 변경사항이라 딱히 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 댓글 API 응답에서 미디어 ID 참조로 변경되었습니다.
  * 댓글 생성 시 공개 상태의 미디어만 사용 가능하도록 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->