### PR TITLE
[OT-225][FIX]: JWT 및 소셜 로그인 코드 변경

### DIFF
--- a/apps/api-admin/src/main/java/com/ott/api_admin/auth/service/AdminAuthService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/auth/service/AdminAuthService.java
@@ -37,7 +37,7 @@ public class AdminAuthService {
 
         // 2. 비밀번호 검증 -> 추후 비밀번호 암호화 하여 검증 예정
         String encodedPassword = member.getPassword();
-        if (encodedPassword == null || !encodedPassword.equals(request.getPassword())) {
+        if (encodedPassword == null || !passwordEncoder.matches(request.getPassword(), encodedPassword)) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
         }
 

--- a/apps/api-admin/src/main/java/com/ott/api_admin/auth/service/AdminAuthService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/auth/service/AdminAuthService.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class AdminAuthService {
 
     private final MemberRepository memberRepository;
@@ -30,6 +29,7 @@ public class AdminAuthService {
      * 관리자 로그인
      * 토큰은 Controller에서 쿠키로 세팅
      */
+    @Transactional
     public AdminLoginResponse login(AdminLoginRequest request) {
         // 1. 이메일 + LOCAL provider로 회원 조회
         Member member = memberRepository.findByEmailAndProvider(request.getEmail(), Provider.LOCAL)
@@ -65,6 +65,7 @@ public class AdminAuthService {
     /**
      * Access 발급 시 + Refresh Token 재발급
      */
+    @Transactional
     public AdminTokenResponse reissue(String refreshToken) {
         // 1. refresh token 검증
         ErrorCode errorCode = jwtTokenProvider.validateAndGetErrorCode(refreshToken);
@@ -86,12 +87,18 @@ public class AdminAuthService {
             throw new BusinessException(ErrorCode.INVALID_TOKEN);
         }
 
-        // 3. 새 토큰 발급
+        // 3. 권한 재확인 (강등된 계정 차단)
+        if (member.getRole() != Role.ADMIN && member.getRole() != Role.EDITOR) {
+            member.clearRefreshToken();
+            throw new BusinessException(ErrorCode.FORBIDDEN, "관리자 권한이 없습니다.");
+        }
+
+        // 4. 새 토큰 발급
         List<String> authorities = List.of(member.getRole().getKey());
         String newAccessToken = jwtTokenProvider.createAccessToken(memberId, authorities);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId, authorities);
 
-        // 4. refresh token 갱신
+        // 5. refresh token 갱신
         member.clearRefreshToken();
         member.updateRefreshToken(newRefreshToken);
 
@@ -101,6 +108,7 @@ public class AdminAuthService {
     /**
      * 로그아웃 — DB refresh token 삭제
      */
+    @Transactional
     public void logout(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));

--- a/apps/api-admin/src/main/java/com/ott/api_admin/auth/service/AdminAuthService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/auth/service/AdminAuthService.java
@@ -72,6 +72,11 @@ public class AdminAuthService {
             throw new BusinessException(errorCode);
         }
 
+        // 추가: refresh 토큰 타입 검증
+        if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+
         // 2. DB 토큰 일치 확인
         Long memberId = jwtTokenProvider.getMemberId(refreshToken);
         Member member = memberRepository.findById(memberId)

--- a/apps/api-admin/src/main/java/com/ott/api_admin/auth/service/AdminAuthService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/auth/service/AdminAuthService.java
@@ -35,12 +35,11 @@ public class AdminAuthService {
         Member member = memberRepository.findByEmailAndProvider(request.getEmail(), Provider.LOCAL)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        // 2. 비밀번호 검증
-//        String encodedPassword = member.getPassword();
-//        if (encodedPassword == null || !passwordEncoder.matches(request.getPassword(), encodedPassword)) {
-//            throw new BusinessException(ErrorCode.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
-//        }
-
+        // 2. 비밀번호 검증 -> 추후 비밀번호 암호화 하여 검증 예정
+        String encodedPassword = member.getPassword();
+        if (encodedPassword == null || !encodedPassword.equals(request.getPassword())) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
+        }
 
         // 3. 권한 확인 (ADMIN, EDITOR만 허용)
         if (member.getRole() != Role.ADMIN && member.getRole() != Role.EDITOR) {

--- a/apps/api-admin/src/main/java/com/ott/api_admin/auth/service/AdminAuthService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/auth/service/AdminAuthService.java
@@ -87,7 +87,7 @@ public class AdminAuthService {
         }
 
         // 3. 새 토큰 발급
-        List<String> authorities = jwtTokenProvider.getAuthorities(refreshToken);
+        List<String> authorities = List.of(member.getRole().getKey());
         String newAccessToken = jwtTokenProvider.createAccessToken(memberId, authorities);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId, authorities);
 

--- a/apps/api-user/src/main/java/com/ott/api_user/auth/service/AuthService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/auth/service/AuthService.java
@@ -49,7 +49,7 @@ public class AuthService {
         }
 
         // 권한 추출
-        List<String> authorities = jwtTokenProvider.getAuthorities(refreshToken);
+        List<String> authorities = List.of(member.getRole().getKey());
 
         // access + refresh 재발급
         String newAccessToken = jwtTokenProvider.createAccessToken(memberId, authorities);

--- a/apps/api-user/src/main/java/com/ott/api_user/auth/service/AuthService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/auth/service/AuthService.java
@@ -35,6 +35,11 @@ public class AuthService {
             throw new BusinessException(errorCode);
         }
 
+        // 추가: refresh 토큰 타입 검증
+        if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+
         // DB에 저장된 토큰과 일치 여부 확인
         Long memberId = jwtTokenProvider.getMemberId(refreshToken);
         Member member = findMemberById(memberId);

--- a/apps/api-user/src/main/java/com/ott/api_user/auth/service/KakaoAuthService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/auth/service/KakaoAuthService.java
@@ -32,9 +32,9 @@ public class KakaoAuthService {
                 .findByProviderAndProviderId(Provider.KAKAO, kakaoUserInfo.getProviderId())
                 .map(existingMember -> {
                     existingMember.reactivate();
-                    existingMember.updateKakaoProfile(
-                            kakaoUserInfo.getEmail(),
-                            kakaoUserInfo.getNickname());
+//                    existingMember.updateKakaoProfile(
+//                            kakaoUserInfo.getEmail(),
+//                            kakaoUserInfo.getNickname());
                     return existingMember;
                 })
                 .orElseGet(() -> memberRepository.save(

--- a/modules/common-security/src/main/java/com/ott/common/security/filter/JwtAuthenticationFilter.java
+++ b/modules/common-security/src/main/java/com/ott/common/security/filter/JwtAuthenticationFilter.java
@@ -44,21 +44,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             ErrorCode errorCode = jwtTokenProvider.validateAndGetErrorCode(token);
 
             if(errorCode == null) {
-                Long memberId = jwtTokenProvider.getMemberId(token);
+                // refresh 토큰으로 API 접근 차단
+                if(!jwtTokenProvider.isAccessToken(token)){
+                    request.setAttribute(JwtAuthenticationEntryPoint.ERROR_CODE, ErrorCode.INVALID_TOKEN);
+                } else {
+                    Long memberId = jwtTokenProvider.getMemberId(token);
 
-                // auth: ["ROLE_USER"]
-                List<String> authorities = jwtTokenProvider.getAuthorities(token);
+                    // auth: ["ROLE_USER"]
+                    List<String> authorities = jwtTokenProvider.getAuthorities(token);
 
-                // Authentication을 만듬 -> 민감한 정보 저장 x
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                        memberId, // principal // 추후 UserDetails로 변경할 예정 아마도
-                        null, // credentials
-                        authorities.stream() // grantedAuthorities
-                                .map(SimpleGrantedAuthority::new)
-                                .toList()
-                );
-                // Authenication을 SecurityContext에 넣음
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                    // Authentication을 만듬 -> 민감한 정보 저장 x
+                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                            memberId, // principal // 추후 UserDetails로 변경할 예정 아마도
+                            null, // credentials
+                            authorities.stream() // grantedAuthorities
+                                    .map(SimpleGrantedAuthority::new)
+                                    .toList()
+                    );
+                    // Authenication을 SecurityContext에 넣음
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             } else {
                 // 실패할 경우 해당 에러코드를 reqeust에 넣음
                 request.setAttribute(JwtAuthenticationEntryPoint.ERROR_CODE, errorCode);

--- a/modules/common-security/src/main/java/com/ott/common/security/jwt/JwtTokenProvider.java
+++ b/modules/common-security/src/main/java/com/ott/common/security/jwt/JwtTokenProvider.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class JwtTokenProvider {
 
     private static final String CLAIM_AUTH = "auth";
+    private static final String CLAIM_TYPE = "type";
 
     private final SecretKey key;
     private final long accessTokenExpiry;
@@ -40,23 +41,25 @@ public class JwtTokenProvider {
 
     // Access JWT 생성
     public String createAccessToken(Long memberId, List<String> authorities) {
-        return createToken(memberId, authorities, accessTokenExpiry);
+        return createToken(memberId, authorities, accessTokenExpiry, "access");
     }
 
     // Refresh JWT 생성
     public String createRefreshToken(Long memberId, List<String> authorities) {
-        return createToken(memberId, authorities, refreshTokenExpiry);
+        return createToken(memberId, authorities, refreshTokenExpiry, "refresh");
     }
 
     // JWT 생성
     // header는 자동으로 생김
     // claim -> sub, auth, iat(issued at), exp(expiration)이 들어감
+    // claim -> 추가로 type을 넣어서 access, refresh 토큰 구별
     // signature -> Ec(header+payload)
-    private String createToken(Long memberId, List<String> authorities, long expiryMillis) {
+    private String createToken(Long memberId, List<String> authorities, long expiryMillis, String type) {
         Date now = new Date();
         return Jwts.builder()
                 .subject(String.valueOf(memberId))
                 .claim(CLAIM_AUTH, authorities) // ["ROLE_MEMBER", "ROLE_ADMIN", "ROLE_EDITOR"]
+                .claim(CLAIM_TYPE, type)
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + expiryMillis))
                 .signWith(key) // 서명
@@ -96,6 +99,15 @@ public class JwtTokenProvider {
         } catch (JwtException | IllegalArgumentException e) {
             return ErrorCode.INVALID_TOKEN; // A002
         }
+    }
+
+    // 타입 검증 메서드
+    public boolean isAccessToken(String token) {
+        return "access".equals(getClaims(token).get(CLAIM_TYPE));
+    }
+
+    public boolean isRefreshToken(String token) {
+        return "refresh".equals(getClaims(token).get(CLAIM_TYPE));
     }
 
 }

--- a/modules/common-security/src/main/java/com/ott/common/security/util/CookieUtil.java
+++ b/modules/common-security/src/main/java/com/ott/common/security/util/CookieUtil.java
@@ -8,13 +8,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class CookieUtil {
 
-    public void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+    public void addCookie(HttpServletResponse response, String name, String value, int maxAgeMillis) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .domain("openthetaste.cloud")  // 로컬 테스트 시 주석처리!!!
                 .httpOnly(true) // JS 접근 차단 -> 크로스 사이트 스크립트 공격 대비
                 .secure(true) // HTTPS 요청만 허용
                 .path("/")  // 모든 경로로 전송
-                .maxAge(maxAge)
+                .maxAge(maxAgeMillis / 1000) // 밀리초 → 초 변환
                 .sameSite("None")  // 크로스 사이트에 대해서 쿠키 전송 허용
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 카카오 로그인 시 매번 카카오 프로필로 업데이트하는 코드 주석 처리
- [x] 쿠키 만료 시간 일치하도록 until쪽 밀리초 -> 초로 변환
- [x] 비밀번호 검증 코드 도입 (복호화는 DB 셋업 이후 진행)
- [x] JWT 발급 시 claim에 type을 부여
     > 문제:  JWT 발급 시 access/refresh 구분을 하지 않아서
refresh 토큰을 access 토큰 쿠키에 넣으면 해당 API가 호출되는 이슈 발생
해결: 토큰 생성 시 claim에 type을 부여하여 refresh 토큰으로 API 호출이 불가능하여 attack surface를 줄임
- [x] reissue 시 DB의 최신 role를 조회 하도록 수정
   > 문제:  refresh 토큰의 claim에서 role를 조회했는데, 이 경우 DB상에서 
   EDITOR -> SUSPEND로 강등되어도, refresh토큰이 살아있는
   14일동안은 권한 인증을 통과하는 이슈가 발생
해결 : 서비스단에서 claim 대신 DB에서 최신 role를 조회하여 권한 오용을 방지함

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
close #124 


## 💬 리뷰 요구사항
해당 pr 머지 후 기존 refresh Token 재사용이 불가능합니다.
자세히는 기존 토큰 속 claim에는 type이 없어서 인증이 불가능 합니다.
따라서, 운영, 로컬 DB의 모든 멤버에 대한 refreshToke 삭제를 해야 합니다. 

`UPDATE member SET refresh_token = NULL WHERE refresh_token IS NOT NULL;`
해당 코드를 꼭 실행시켜주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * JWT 토큰에 타입(액세스/리프레시) 클레임 추가로 토큰 검증 강화

* **Bug Fixes**
  * 인증 흐름에서 토큰 타입(액세스/리프레시) 검증 추가
  * 리프레시 재발급 시 토큰 종류 검증 및 역할 기반 접근 차단 추가
  * 토큰 재발급 시 권한 정보를 사용자 역할에서 파생하도록 변경
  * 로그인 시 실제 비밀번호 검증 활성화

* **Chores**
  * 쿠키 만료값을 밀리초 단위로 수신하여 내부에서 처리하도록 개선
  * 트랜잭션 적용 범위를 메서드 단위로 조정하여 안정성 향상

* **Other**
  * 외부 로그인 시 기존 프로필(이메일/닉네임) 동기화 동작 비활성화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->