### PR TITLE
[OT-196][CHORE]:공통 0번에서 각 컨트롤러마다 0번 응답 코드를 가지도록 수정

### DIFF
--- a/apps/api-user/src/main/java/com/ott/api_user/ApiUserApplication.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/ApiUserApplication.java
@@ -16,6 +16,7 @@ public class ApiUserApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(ApiUserApplication.class, args);
+		
 	}
 
 }

--- a/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlayListAPI.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlayListAPI.java
@@ -53,8 +53,12 @@ public interface PlayListAPI {
 
         
         @Operation(summary = "선호 태그 순위별 리스트", description = "유저의 Top 3 태그 순위를 기반으로 제공합니다.")
-        @ApiResponses(
-                @ApiResponse(responseCode = "0", description = "태그 순위별 조회 성공", content = @Content(schema = @Schema(implementation = TopTagPlaylistResponse.class))))
+        @ApiResponses(value = {
+                @ApiResponse(responseCode = "200", description = "태그 순위별 조회 성공", 
+                        content = @Content(mediaType = "application/json", schema = @Schema(implementation = TopTagPlaylistResponse.class))),
+                @ApiResponse(responseCode = "0", description = "태그 순위별 DTO 응답 구조", 
+                        content = @Content(mediaType = "application/json", schema = @Schema(implementation = TopTagPlaylistResponse.class)))
+        })
         @GetMapping("/tags/top")
         ResponseEntity<SuccessResponse<TopTagPlaylistResponse>> getTopTagPlaylists(
                 @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
@@ -70,7 +74,7 @@ public interface PlayListAPI {
         @ApiResponse(responseCode = "0", description = "플레이리스트 DTO 응답 구조", 
                 content = @Content(mediaType = "application/json", schema = @Schema(implementation = PlaylistResponse.class)))
         @ApiResponse(responseCode = "404", description = "해당 태그를 찾을 수 없음", 
-                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
         @GetMapping("/tags/{tagId}")
         ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getTagPlaylists(
                 @Parameter(description = "태그 ID", required = true) @PathVariable(value = "tagId") Long tagId,

--- a/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlayListAPI.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/playlist/controller/PlayListAPI.java
@@ -32,8 +32,6 @@ import java.util.List;
 @SecurityRequirement(name = "BearerAuth") // 인증인가 확인
 @Tag(name = "Playlist", description = "플레이리스트& 재생목록 API, excludeMediaId 는 재생목록 API 호출 시에만 포함시킵니다")
 @ApiResponses(value = {
-    @ApiResponse(responseCode = "0", description = "플레이리스트 DTO 응답 구조", 
-        content = @Content(mediaType = "application/json", schema = @Schema(implementation = PlaylistResponse.class))),
     @ApiResponse(responseCode = "200", description = "조회 성공", 
         content = @Content(mediaType = "application/json", schema = @Schema(implementation = PageResponse.class))),
     @ApiResponse(responseCode = "401", description = "인증 실패", 
@@ -43,6 +41,8 @@ import java.util.List;
 })
 public interface PlayListAPI {
         @Operation(summary = "OO 님이 좋아하실만한 콘텐츠", description = "유저 취향을 합산하여 추천합니다. (홈 화면 셔플 지원)")
+        @ApiResponse(responseCode = "0", description = "플레이리스트 DTO 응답 구조", 
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = PlaylistResponse.class)))
         @GetMapping("/recommend")
         ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getRecommendPlaylists(
                 @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
@@ -52,10 +52,9 @@ public interface PlayListAPI {
         );
 
         
-
         @Operation(summary = "선호 태그 순위별 리스트", description = "유저의 Top 3 태그 순위를 기반으로 제공합니다.")
         @ApiResponses(
-                @ApiResponse(responseCode = "200", description = "태그 순위별 조회 성공", content = @Content(schema = @Schema(implementation = TopTagPlaylistResponse.class))))
+                @ApiResponse(responseCode = "0", description = "태그 순위별 조회 성공", content = @Content(schema = @Schema(implementation = TopTagPlaylistResponse.class))))
         @GetMapping("/tags/top")
         ResponseEntity<SuccessResponse<TopTagPlaylistResponse>> getTopTagPlaylists(
                 @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
@@ -68,7 +67,10 @@ public interface PlayListAPI {
         
 
         @Operation(summary = "상세 페이지 - 특정 해시태그 리스트", description = "해당 태그의 영상만 제공합니다.")
-        @ApiResponse(responseCode = "404", description = "해당 태그를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+        @ApiResponse(responseCode = "0", description = "플레이리스트 DTO 응답 구조", 
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = PlaylistResponse.class)))
+        @ApiResponse(responseCode = "404", description = "해당 태그를 찾을 수 없음", 
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         @GetMapping("/tags/{tagId}")
         ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getTagPlaylists(
                 @Parameter(description = "태그 ID", required = true) @PathVariable(value = "tagId") Long tagId,
@@ -79,6 +81,8 @@ public interface PlayListAPI {
         );
 
         @Operation(summary = "인기 차트 (Trending)", description = "북마크가 많은 인기 순서대로 제공합니다.")
+        @ApiResponse(responseCode = "0", description = "플레이리스트 DTO 응답 구조", 
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = PlaylistResponse.class)))
         @GetMapping("/trending")
         ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getTrendingPlaylists(
                 @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
@@ -88,6 +92,8 @@ public interface PlayListAPI {
         );
 
         @Operation(summary = "시청 이력 (History)", description = "유저가 최근 시청한 영상 목록을 제공합니다.")
+        @ApiResponse(responseCode = "0", description = "플레이리스트 DTO 응답 구조", 
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = PlaylistResponse.class)))
         @GetMapping("/history")
         ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getHistoryPlaylists(
                 @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
@@ -97,6 +103,8 @@ public interface PlayListAPI {
         );
 
         @Operation(summary = "북마크 목록 (Bookmark)", description = "유저가 북마크한 영상 목록을 제공합니다.")
+        @ApiResponse(responseCode = "0", description = "플레이리스트 DTO 응답 구조", 
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = PlaylistResponse.class)))
         @GetMapping("/bookmarks")
         ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getBookmarkPlaylists(
                 @Parameter(description = "현재 영상 ID") @RequestParam(value = "excludeMediaId", required = false) Long excludeMediaId,
@@ -106,6 +114,8 @@ public interface PlayListAPI {
         );
 
         @Operation(summary = "검색 상세 페이지 재생목록", description = "검색 결과에서 진입 시 종합 추천 리스트로 대체하여 제공합니다.")
+        @ApiResponse(responseCode = "0", description = "플레이리스트 DTO 응답 구조", 
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = PlaylistResponse.class)))
         @GetMapping("/search")
         ResponseEntity<SuccessResponse<PageResponse<PlaylistResponse>>> getSearchPlaylists(
                 @Parameter(description = "현재 영상 ID", required = true) @RequestParam(value = "excludeMediaId") Long excludeMediaId,


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [ ] 이전 PR 에서는 0번 응답을 공통 포맷으로 가지도록 구성했는데 이렇게 하면 TopTagPlaylistResponse 의 응답구조가 0번으로 뒤덮히는 문제가 발생하여, 공통 0번 포맷에서 각각의 컨트롤러가 0번 응답 코드를 가지도록 수정하였습니다.



### 📷 스크린샷
<img width="1351" height="522" alt="image" src="https://github.com/user-attachments/assets/ec5c9a27-ca7d-4b8e-ac7f-4f074f508cb8" />

**변경 전 응답**
<img width="1565" height="576" alt="image" src="https://github.com/user-attachments/assets/b5f4996e-307f-4975-8f51-15c1ea92e760" />



**변경 후 응답**
<img width="1384" height="751" alt="image" src="https://github.com/user-attachments/assets/c4375b68-152a-4137-b3df-bb2aa5a972b9" />



## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [ ] 테스트는 잘 통과했나요?
- [ ] 충돌을 해결했나요?
- [ ] 이슈는 등록했나요?
- [ ] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) #107 
closes #107 


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 추천, 인기 태그, 태그별, 트렌딩, 히스토리, 북마크, 검색 등 플레이리스트 조회 API 각 엔드포인트에 대한 응답 구조 설명을 세부화하고 명확히 개선했습니다. 응답 형식과 반환 DTO 구조가 엔드포인트별로 상세히 문서화되어 API 사용 시 기대되는 응답을 더 정확히 파악할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->