### PR TITLE
[OT-235] [FIX]: contents 상세에 seriesId, series/titles에 category/tag 응답 추가

### DIFF
--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/dto/response/ContentsDetailResponse.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/dto/response/ContentsDetailResponse.java
@@ -12,6 +12,8 @@ public record ContentsDetailResponse(
 
         @Schema(type = "Long", description = "콘텐츠 ID", example = "1") Long contentsId,
 
+        @Schema(type = "Long", description = "시리즈 ID", example = "1") Long seriesId,
+
         @Schema(type = "String", description = "포스터 URL", example = "https://cdn.example.com/poster.jpg") String posterUrl,
 
         @Schema(type = "String", description = "썸네일 URL", example = "https://cdn.example.com/thumb.jpg") String thumbnailUrl,

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/mapper/BackOfficeContentsMapper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/mapper/BackOfficeContentsMapper.java
@@ -24,12 +24,13 @@ public class BackOfficeContentsMapper {
         );
     }
 
-    public ContentsDetailResponse toContentsDetailResponse(Contents contents, Media media, String uploaderNickname, String seriesTitle, List<MediaTag> mediaTagList) {
+    public ContentsDetailResponse toContentsDetailResponse(Long seriesId, Contents contents, Media media, String uploaderNickname, String seriesTitle, List<MediaTag> mediaTagList) {
         String categoryName = extractCategoryName(mediaTagList);
         List<String> tagNameList = extractTagNameList(mediaTagList);
 
         return new ContentsDetailResponse(
                 contents.getId(),
+                seriesId,
                 media.getPosterUrl(),
                 media.getThumbnailUrl(),
                 media.getTitle(),

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
@@ -81,16 +81,18 @@ public class BackOfficeContentsService {
         // 2. 소속 시리즈 제목 및 태그 추출
         Long originMediaId = mediaId;
         String seriesTitle = null;
+        Long seriesId = null;
         if (contents.getSeries() != null) {
             Media originMedia = contents.getSeries().getMedia();
             originMediaId = originMedia.getId();
             seriesTitle = originMedia.getTitle();
+            seriesId = contents.getSeries().getId();
         }
 
         // 3. 태그 조회
         List<MediaTag> mediaTagList = mediaTagRepository.findWithTagAndCategoryByMediaId(originMediaId);
 
-        return backOfficeContentsMapper.toContentsDetailResponse(contents, media, uploaderNickname, seriesTitle, mediaTagList);
+        return backOfficeContentsMapper.toContentsDetailResponse(seriesId, contents, media, uploaderNickname, seriesTitle, mediaTagList);
     }
 
     @Transactional

--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/dto/response/SeriesTitleListResponse.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/dto/response/SeriesTitleListResponse.java
@@ -2,6 +2,8 @@ package com.ott.api_admin.series.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 @Schema(description = "시리즈 제목 목록 조회 응답")
 public record SeriesTitleListResponse(
 
@@ -9,6 +11,12 @@ public record SeriesTitleListResponse(
         Long seriesId,
 
         @Schema(type = "String", description = "시리즈 제목", example = "비밀의 숲")
-        String title
+        String title,
+
+        @Schema(type = "String", description = "카테고리명", example = "드라마")
+        String categoryName,
+
+        @Schema(type = "List<String>", description = "태그 이름 목록", example = "[\"스릴러\", \"추리\"]")
+        List<String> tagNameList
 ) {
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/mapper/BackOfficeSeriesMapper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/mapper/BackOfficeSeriesMapper.java
@@ -29,10 +29,15 @@ public class BackOfficeSeriesMapper {
         );
     }
 
-    public SeriesTitleListResponse toSeriesTitleList(Series series) {
+    public SeriesTitleListResponse toSeriesTitleList(Series series, List<MediaTag> mediaTagList) {
+        String categoryName = extractCategoryName(mediaTagList);
+        List<String> tagNameList = extractTagNameList(mediaTagList);
+
         return new SeriesTitleListResponse(
                 series.getId(),
-                series.getMedia().getTitle()
+                series.getMedia().getTitle(),
+                categoryName,
+                tagNameList
         );
     }
 

--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/service/BackOfficeSeriesService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/service/BackOfficeSeriesService.java
@@ -82,8 +82,18 @@ public class BackOfficeSeriesService {
 
         Page<Series> seriesPage = seriesRepository.findSeriesListWithMediaBySearchWord(pageable, searchWord);
 
+        List<Long> mediaIdList = seriesPage.getContent().stream()
+                .map(series -> series.getMedia().getId())
+                .toList();
+
+        Map<Long, List<MediaTag>> tagListByMediaId = mediaTagRepository.findWithTagAndCategoryByMediaIds(mediaIdList).stream()
+                .collect(Collectors.groupingBy(mt -> mt.getMedia().getId()));
+
         List<SeriesTitleListResponse> responseList = seriesPage.getContent().stream()
-                .map(backOfficeSeriesMapper::toSeriesTitleList)
+                .map(series -> backOfficeSeriesMapper.toSeriesTitleList(
+                        series,
+                        tagListByMediaId.getOrDefault(series.getMedia().getId(), List.of())
+                ))
                 .toList();
 
         PageInfo pageInfo = PageInfo.toPageInfo(

--- a/apps/api-admin/src/main/java/com/ott/api_admin/series/service/BackOfficeSeriesService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/series/service/BackOfficeSeriesService.java
@@ -86,7 +86,9 @@ public class BackOfficeSeriesService {
                 .map(series -> series.getMedia().getId())
                 .toList();
 
-        Map<Long, List<MediaTag>> tagListByMediaId = mediaTagRepository.findWithTagAndCategoryByMediaIds(mediaIdList).stream()
+        Map<Long, List<MediaTag>> tagListByMediaId = mediaIdList.isEmpty()
+                ? Collections.emptyMap()
+                : mediaTagRepository.findWithTagAndCategoryByMediaIds(mediaIdList).stream()
                 .collect(Collectors.groupingBy(mt -> mt.getMedia().getId()));
 
         List<SeriesTitleListResponse> responseList = seriesPage.getContent().stream()


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] contents 상세에 seriesId, series/titles에 category/tag 응답 추가

## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호
#130 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 콘텐츠 상세 조회 응답에 시리즈 ID가 추가되어 상세 정보에서 시리즈 연동을 확인할 수 있습니다.
  * 시리즈 제목 목록 조회 시 카테고리명과 각 시리즈에 해당하는 태그 목록이 함께 제공되어 검색·필터링 및 정보 파악이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->