### PR TITLE
[OT-238][FIX]: 시청 이력 조회 시 시리즈물 누락 버그 수정

### DIFF
--- a/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryImpl.java
@@ -261,7 +261,7 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
                         // 4. 동일한 시리즈(드라마)의 여러 에피소드를 봤더라도 대표 썸네일 1개로 병합
                         .groupBy(media.id)
                         // 5. 묶인 에피소드들 중 가장 최근(Max)에 시청한 시간을 기준으로 내림차순 정렬
-                        .orderBy(playback.modifiedDate.max().desc())
+                        .orderBy(playback.modifiedDate.max().desc() , media.id.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
                         .fetch();

--- a/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryImpl.java
@@ -29,7 +29,7 @@ import static com.ott.domain.common.Status.ACTIVE;
 import static com.ott.domain.media.domain.QMedia.media;
 import static com.ott.domain.bookmark.domain.QBookmark.bookmark;
 import static com.ott.domain.media_tag.domain.QMediaTag.mediaTag;
-
+import static com.ott.domain.series.domain.QSeries.series;
 
 
 
@@ -234,34 +234,55 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
 
         @Override
         public Page<Media> findHistoryPlaylists(Long memberId, MediaType mediaType, Long excludeMediaId, Pageable pageable) {
-                List<Media> content = queryFactory
-                                .select(media)
-                                .from(playback)
-                                .join(playback.contents.media, media) // 시청 기록과 미디어 정보 조인
-                                .where(
-                                                playback.member.id.eq(memberId), // 특정 사용자 필터링
-                                                mediaTypeEq(mediaType),
-                                                isActiveAndPublic(), // 활성/공개 상태 확인
-                                                isDisplayable(),
-                                                excludeId(excludeMediaId) // 현재 재생 중인 영상 제외
-                                )
-                                .orderBy(playback.modifiedDate.desc()) // 최근 시청 시점 순 정렬
-                                .offset(pageable.getOffset())
-                                .limit(pageable.getPageSize())
-                                .fetch();
+                List<Media> contentList = queryFactory
+                        .select(media)
+                        .from(playback)
+                        // 1. 유저가 시청한 실제 영상(에피소드 or 단편) 조인
+                        .join(playback.contents, contents)
+                        // 2. 에피소드일 경우를 대비해 Series 레프트 조인
+                        .leftJoin(contents.series, series)
+                        
+                        // 3. 핵심 마법: 상황에 맞춰 알맞은 대표 Media를 물고 옵니다!
+                        .join(media).on(
+                                // 단편(영화)인 경우: 시청한 영상 자체의 Media를 조인
+                                series.isNull().and(media.id.eq(contents.media.id))
+                                // 에피소드인 경우: 부모인 Series가 가진 대표 Media를 조인
+                                .or(series.isNotNull().and(media.id.eq(series.media.id)))
+                        )
+                        
+                        .where(
+                                playback.member.id.eq(memberId),
+                                mediaTypeEq(mediaType),
+                                isActiveAndPublic(), 
+                                excludeId(excludeMediaId)
+                                // isDisplayable()은 위 조인 로직으로 인해 자연스럽게 충족되므로 뺐습니다!
+                        )
+                        
+                        // 4. 동일한 시리즈(드라마)의 여러 에피소드를 봤더라도 대표 썸네일 1개로 병합
+                        .groupBy(media.id)
+                        // 5. 묶인 에피소드들 중 가장 최근(Max)에 시청한 시간을 기준으로 내림차순 정렬
+                        .orderBy(playback.modifiedDate.max().desc())
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
 
                 JPAQuery<Long> countQuery = queryFactory
-                                .select(playback.count())
-                                .from(playback)
-                                .join(playback.contents.media, media)
-                                .where(
-                                                playback.member.id.eq(memberId),
-                                                mediaTypeEq(mediaType),
-                                                isActiveAndPublic(),
-                                                isDisplayable(),
-                                                excludeId(excludeMediaId));
+                        .select(media.id.countDistinct()) // 페이징 개수 계산 시에도 중복 제거
+                        .from(playback)
+                        .join(playback.contents, contents)
+                        .leftJoin(contents.series, series)
+                        .join(media).on(
+                                series.isNull().and(media.id.eq(contents.media.id))
+                                .or(series.isNotNull().and(media.id.eq(series.media.id)))
+                        )
+                        .where(
+                                playback.member.id.eq(memberId),
+                                mediaTypeEq(mediaType),
+                                isActiveAndPublic(),
+                                excludeId(excludeMediaId)
+                        );
 
-                return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+                return PageableExecutionUtils.getPage(contentList, pageable, countQuery::fetchOne);
         }
 
         @Override


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

문제점: 
유저의 시청 이력 플레이리스트(GET /playlists/history) API 호출 시, 
단편 영상은 정상적으로 반환되나
**시리즈물(드라마 등)의 에피소드 시청 기록**이 목록에서 누락되는 현상이 발생
- 에피소드를 시청하면, 시리즈 본체가 시청 기록에 떠야함.

- 따라서 현재 isDisplayable() 방어 메소드를 QueryDsl 조인에서 사용하지 않고, 조인 방향을 
-  playback -> conetents 에서 media -> contents -> playback  으로 수정함.

### 📷 스크린샷
<img width="1361" height="668" alt="image" src="https://github.com/user-attachments/assets/d81cfc1a-ce4c-4246-8f7e-f3904db8567e" />


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [ ] 테스트는 잘 통과했나요?
- [ ] 충돌을 해결했나요?
- [ ] 이슈는 등록했나요?
- [ ] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) #135 
closes #135 


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 리팩토링

* **리팩토링**
  * 미디어 재생 이력 조회 로직 개선: 에피소드가 속한 시리즈를 그룹화해 동일 미디어 중복을 제거하고, 최신 재생일자 기준으로 정렬해 결과 정확도 및 조회 효율 향상.
  * 내부 쿼리 집계 방식 보완으로 페이징과 카운트 계산 안정화.

---

**참고:** 이 변경은 내부 처리 최적화에 국한되며 공개 API에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->