### PR TITLE
[OT-253][FEAT]: JPQL사용에 따른 영속성 컨텍스트 오류 수정

### DIFF
--- a/apps/api-user/src/main/java/com/ott/api_user/auth/service/KakaoAuthService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/auth/service/KakaoAuthService.java
@@ -34,10 +34,6 @@ public class KakaoAuthService {
         return memberRepository
                 .findByProviderAndProviderId(Provider.KAKAO, kakaoUserInfo.getProviderId())
                 .map(existingMember -> {
-                    existingMember.reactivate();
-//                    existingMember.updateKakaoProfile(
-//                          kakaoUserInfo.getEmail(),
-//                          kakaoUserInfo.getNickname());
                     reactivateRadarPreference(existingMember);
                     return existingMember;
                 })

--- a/apps/api-user/src/main/java/com/ott/api_user/member/service/MemberService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/member/service/MemberService.java
@@ -4,12 +4,8 @@ import com.ott.api_user.auth.client.KakaoUnlinkClient;
 import com.ott.api_user.member.dto.request.SetPreferredTagRequest;
 import com.ott.api_user.member.dto.request.UpdateMemberRequest;
 import com.ott.api_user.member.dto.response.*;
-import com.ott.api_user.playlist.dto.response.RecentWatchResponse;
-import com.ott.api_user.playlist.dto.response.TagPlaylistResponse;
 import com.ott.common.web.exception.BusinessException;
 import com.ott.common.web.exception.ErrorCode;
-import com.ott.common.web.response.PageInfo;
-import com.ott.common.web.response.PageResponse;
 import com.ott.domain.bookmark.repository.BookmarkRepository;
 import com.ott.domain.click_event.repository.ClickRepository;
 import com.ott.domain.comment.repository.CommentRepository;
@@ -25,11 +21,8 @@ import com.ott.domain.preferred_tag.domain.PreferredTag;
 import com.ott.domain.preferred_tag.repository.PreferredTagRepository;
 import com.ott.domain.tag.domain.Tag;
 import com.ott.domain.tag.repository.TagRepository;
-import com.ott.domain.watch_history.repository.RecentWatchProjection;
 import com.ott.domain.watch_history.repository.WatchHistoryRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -160,16 +153,21 @@ public class MemberService {
 
         // 벌크 쿼리 이후 영속성 컨텍스트가 초기화 되기 때문에 member.withdraw 먼저 수행
         // JPA가 변경 감지를 못해서 순서 변경
-        // 2. 회원 Soft Delete
-        member.withdraw();
+        // 2. 회원 Soft Delete ->
+//        member.withdraw();
+        memberRepository.softDeleteByMemberId(memberId);
 
-        // 탈퇴 회원의 ACTIVE한 북마크 수 차감
-        bookmarkRepository.decreaseBookmarkCountByMemberId(memberId);
+        // 탈퇴 회원의 ACTIVE한 북마크, 좋아요 수 차감 x -> 통계에 사용되는 데이터임
+        /**
+         * 해당 쿼리문은 JPQL bulk update 연산으로 DB로 직접 접근하여 실행함
+         * 그 다음 EntityNamger.clear()를 호출하는데 이때 영속성 컨텍스트가 비워짐
+         * 그래서 해당 트랜잭션이 끝나고 영속성 컨텍스트와 변경점을 찾아서 쿼리를 날리는데,
+         * 영속성 컨텍스트가 비워졌기 때문에 member.withdraw() 쿼리가 안날라감
+         *
+         * flushAutomatically : 반영 안된 변경 먼저 DB에 업데이트
+         * clearAutomatically : 해당 쿼리 실행 후 캐시된 엔티티 상태를 비워서 DB와 일치시킴
+         */
         bookmarkRepository.softDeleteAllByMemberId(memberId);
-
-
-        // 탈퇴 회원의 ACTIVE한 좋아요 수 차감
-        likesRepository.decreaseLikesCountByMemberId(memberId);
         likesRepository.softDeleteAllByMemberId(memberId);
 
         // 3. 연관 데이터 Soft Delete
@@ -177,7 +175,6 @@ public class MemberService {
         watchHistoryRepository.softDeleteAllByMemberId(memberId);
         playbackRepository.softDeleteAllByMemberId(memberId);
         commentRepository.softDeleteAllByMemberId(memberId);
-        clickRepository.softDeleteAllByMemberId(memberId);
         memberRadarPreferenceRepository.softDeleteByMemberId(memberId);
     }
 

--- a/modules/domain/src/main/java/com/ott/domain/bookmark/repository/BookmarkRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/bookmark/repository/BookmarkRepository.java
@@ -37,21 +37,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, Bookm
     void softDeleteAllByMemberId(@Param("memberId") Long memberId);
 
 
-    // 회원 탈퇴 전 ACTIVE인 유저가 북마크 row 상태 변경
-    @Modifying(clearAutomatically = true)
-    @Query(value = """
-    UPDATE media m
-    JOIN (
-        SELECT b.media_id
-        FROM bookmark b
-        WHERE b.member_id = :memberId
-          AND b.status = 'ACTIVE'
-    ) t ON t.media_id = m.id
-    SET m.bookmark_count = GREATEST(0, m.bookmark_count - 1)
-    """, nativeQuery = true)
-    void decreaseBookmarkCountByMemberId(@Param("memberId") Long memberId);
-
-
     //주어진 미디어 중 북마크한 미디어들의 Id 리스트 조회
     @Query("SELECT b.media.id FROM Bookmark b " +
            "WHERE b.member.id = :memberId " +

--- a/modules/domain/src/main/java/com/ott/domain/likes/repository/LikesRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/likes/repository/LikesRepository.java
@@ -38,20 +38,6 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
     @Query("UPDATE Likes l SET l.status = 'DELETE' WHERE l.member.id = :memberId")
     void softDeleteAllByMemberId(@Param("memberId") Long memberId);
 
-    // 회원 탈퇴 시 해당 유저가 좋아요한 미디어에 대하여 -count
-    @Modifying(clearAutomatically = true)
-    @Query(value = """
-    UPDATE media m
-    JOIN (
-        SELECT l.media_id
-        FROM likes l
-        WHERE l.member_id = :memberId
-          AND l.status = 'ACTIVE'
-    ) t ON t.media_id = m.id
-    SET m.likes_count = GREATEST(0, m.likes_count - 1)
-    """, nativeQuery = true)
-    void decreaseLikesCountByMemberId(@Param("memberId") Long memberId);
-
 
     @Query("SELECT l.media.id FROM Likes l " +
            "WHERE l.member.id = :memberId " +

--- a/modules/domain/src/main/java/com/ott/domain/member/domain/Member.java
+++ b/modules/domain/src/main/java/com/ott/domain/member/domain/Member.java
@@ -64,11 +64,6 @@ public class Member extends BaseEntity {
                 .build();
     }
 
-    public void updateKakaoProfile(String email, String nickname) {
-        this.email = email;
-        this.nickname = nickname;
-    }
-
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
@@ -94,16 +89,11 @@ public class Member extends BaseEntity {
         this.onboardingCompleted = true;
     }
 
-    // 회원 탈퇴 - Soft Delete (refreshToken 초기화 + status DELETE)
+    // 회원 탈퇴 - Soft Delete (refreshToken 초기화 + status DELETE, providerid = null)
     public void withdraw() {
         this.refreshToken = null;
+        this.providerId = null;
         this.updateStatus(Status.DELETE);
-    }
-
-    // 탈퇴(DELETE) 상태인 경우에만 ACTIVE로 복구
-    public void reactivate() {
-        if (this.getStatus() == Status.DELETE) {
-            this.updateStatus(Status.ACTIVE);
-        }
+        this.onboardingCompleted = false;
     }
 }

--- a/modules/domain/src/main/java/com/ott/domain/member/domain/Member.java
+++ b/modules/domain/src/main/java/com/ott/domain/member/domain/Member.java
@@ -88,12 +88,4 @@ public class Member extends BaseEntity {
     public void completeOnboarding() {
         this.onboardingCompleted = true;
     }
-
-    // 회원 탈퇴 - Soft Delete (refreshToken 초기화 + status DELETE, providerid = null)
-    public void withdraw() {
-        this.refreshToken = null;
-        this.providerId = null;
-        this.updateStatus(Status.DELETE);
-        this.onboardingCompleted = false;
-    }
 }

--- a/modules/domain/src/main/java/com/ott/domain/member/repository/MemberRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/member/repository/MemberRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.ott.domain.common.Status;
 import com.ott.domain.member.domain.Member;
 import com.ott.domain.member.domain.Provider;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
@@ -16,5 +19,17 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
 
     // Active한 유저 조회
     Optional<Member> findByIdAndStatus(Long memberId, Status status);
+
+    // 해당 쿼리는 조회가 아닌 jpql를 사용한 수정, 삭제, 삽입 쿼리임을 명시
+    @Modifying
+    @Query("""
+      UPDATE Member m
+      SET m.refreshToken = null,
+          m.providerId = null,
+          m.onboardingCompleted = false,
+          m.status = 'DELETE'
+      WHERE m.id = :memberId
+      """)
+    void softDeleteByMemberId(@Param("memberId") Long memberId);
 
 }

--- a/modules/domain/src/main/java/com/ott/domain/preferred_tag/repository/PreferredTagRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/preferred_tag/repository/PreferredTagRepository.java
@@ -28,7 +28,7 @@ public interface PreferredTagRepository extends JpaRepository<PreferredTag, Long
                                                                     @Param("status") Status status);
 
     // 선호 태그 삭제,  영속성 컨텍스트 들어있는 내용 삭제
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
     @Query("DELETE FROM PreferredTag pt WHERE pt.member = :member")
     void deleteAllByMember(@Param("member") Member member);
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 온보딩 화면에서 선호 태그 선택 시 JPQL사용으로 영속성 컨텍스트가 clear되어 onboarding_completed 컬럼이 commit 안되는 오류를 해결했습니다.
> JPQL문에 clearAutomatically = true를 지워서 clear 안되도록 수정
- [x] 회원 탈퇴 시 JPQL사용으로 영속성 컨텍스트가 초기화되어 실제 멤버에 대한 update문이 안나가는 오류를 해결했습니다.
> 도메인 내부에서 상태를 변경하는게 아닌 레포지토리에서 상태를 변경하도록 수정했습니다.
단점으로는 엔티티 내부 상태의 책임이 레포지토리로 이전되어 추후 쿼리를 수정해야된다는 단점이 존재하지만
명시적으로 DB를 업데이트할 수 있는 장점이 있어서 해당 방법으로 변경했습니다.

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
close #140 


## 💬 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 기존 회원의 카카오 프로필 자동 갱신 및 자동 재활성화 로직 제거

* **Refactor**
  * 회원 탈퇴 흐름을 일괄 소프트삭제 방식으로 전환하여 관련 데이터 일괄 처리로 단순화
  * 북마크·좋아요 수 직접 감소 로직 제거
  * 회원 관련 공개 재활성화·탈퇴 메서드 제거 및 저장소 기반 소프트삭제 추가
  * 선호 태그 삭제 동작의 영속성 컨텍스트 처리 방식 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->