### PR TITLE
[OT-294] [FIX]: 숏폼 디테일 originId 및 originMediaType 추가

### DIFF
--- a/apps/api-admin/src/main/java/com/ott/api_admin/config/SecurityConfig.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/config/SecurityConfig.java
@@ -84,7 +84,7 @@ public class SecurityConfig {
 
         config.setAllowedOriginPatterns(List.of(
                 "http://localhost:*",
-                "https://www.openthetaste.cloud"));
+                "https://admin.openthetaste.cloud"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/dto/response/ShortFormDetailResponse.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/dto/response/ShortFormDetailResponse.java
@@ -1,5 +1,6 @@
 package com.ott.api_admin.shortform.dto.response;
 
+import com.ott.domain.common.MediaType;
 import com.ott.domain.common.PublicStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -23,6 +24,12 @@ public record ShortFormDetailResponse(
 
         @Schema(type = "String", description = "원본 콘텐츠 제목 (시리즈 혹은 콘텐츠(단편 등))", example = "더글로리 시즌1, 태극기 휘날리며")
         String originContentsTitle,
+
+        @Schema(type = "Long", description = "원본 영상 ID", example = "2")
+        Long originId,
+
+        @Schema(type = "String", description = "원본 영상 타입(시리즈, 콘텐츠)", example = "SERIES")
+        MediaType originType,
 
         @Schema(type = "String", description = "업로더 닉네임", example = "관리자")
         String uploaderNickname,

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/mapper/BackOfficeShortFormMapper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/mapper/BackOfficeShortFormMapper.java
@@ -27,7 +27,15 @@ public class BackOfficeShortFormMapper {
         );
     }
 
-    public ShortFormDetailResponse toShortFormDetailResponse(ShortForm shortForm, Media media, String uploaderNickname, String originMediaTitle, List<MediaTag> mediaTagList) {
+    public ShortFormDetailResponse toShortFormDetailResponse(
+            ShortForm shortForm,
+            Media media,
+            String uploaderNickname,
+            String originMediaTitle,
+            Long originId,
+            MediaType originType,
+            List<MediaTag> mediaTagList
+    ) {
         String categoryName = extractCategoryName(mediaTagList);
         List<String> tagNameList = extractTagNameList(mediaTagList);
 
@@ -37,6 +45,8 @@ public class BackOfficeShortFormMapper {
                 media.getTitle(),
                 media.getDescription(),
                 originMediaTitle,
+                originId,
+                originType,
                 uploaderNickname,
                 shortForm.getDuration(),
                 shortForm.getVideoSize(),

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/service/BackOfficeShortFormService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/service/BackOfficeShortFormService.java
@@ -140,14 +140,23 @@ public class BackOfficeShortFormService {
 
                 Optional<Media> originMedia = shortForm.findOriginMedia();
                 String originMediaTitle = null;
+                Long originId = null;
+                MediaType originType = null;
                 if (originMedia.isPresent()) {
                         originMediaTitle = originMedia.get().getTitle();
+                        if (shortForm.getSeries() != null) {
+                                originId = shortForm.getSeries().getId();
+                                originType = MediaType.SERIES;
+                        } else if (shortForm.getContents() != null) {
+                                originId = shortForm.getContents().getId();
+                                originType = MediaType.CONTENTS;
+                        }
                 }
 
                 List<MediaTag> mediaTagList = mediaTagRepository.findWithTagAndCategoryByMediaId(mediaId);
 
                 return backOfficeShortFormMapper.toShortFormDetailResponse(shortForm, media, uploaderNickname,
-                                originMediaTitle, mediaTagList);
+                                originMediaTitle, originId, originType, mediaTagList);
         }
 
         @Transactional


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 숏폼 디테일 originId 및 originMediaType 추가

## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호
close#160 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 숏폼 상세 정보에 원본 영상의 ID와 미디어 타입이 포함되어 더 풍부한 메타데이터를 제공합니다.
* **Chores**
  * 관리 인터페이스 접근을 위한 허용 출처(origin)를 관리 서브도메인으로 갱신하여 관리자 웹에서의 요청 호환성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->