### PR TITLE
[OT-309] [FEAT]: 멀티 파트 업로드 구현

### DIFF
--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/controller/BackOfficeContentsApi.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/controller/BackOfficeContentsApi.java
@@ -6,6 +6,8 @@ import com.ott.api_admin.content.dto.response.ContentsDetailResponse;
 import com.ott.api_admin.content.dto.response.ContentsListResponse;
 import com.ott.api_admin.content.dto.response.ContentsUpdateResponse;
 import com.ott.api_admin.content.dto.response.ContentsUploadResponse;
+import com.ott.api_admin.upload.dto.request.MultipartUploadCompleteRequest;
+import com.ott.api_admin.upload.dto.response.MultipartUploadPartUrlResponse;
 import com.ott.common.web.exception.ErrorResponse;
 import com.ott.common.web.response.PageResponse;
 import com.ott.common.web.response.SuccessResponse;
@@ -114,5 +116,66 @@ public interface BackOfficeContentsApi {
 
             @Parameter(description = "ContentsUpdateRequest를 참고해주세요.", required = true)
             @Valid @RequestBody ContentsUpdateRequest request
+    );
+
+    @Operation(
+            summary = "콘텐츠 멀티파트 업로드 완료",
+            description = "objectKey, uploadId, 업로드된 part eTag 목록을 사용해 콘텐츠 원본 영상의 S3 멀티파트 업로드를 완료합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "멀티파트 업로드 완료 성공",
+                    content = {@Content(mediaType = "application/json")}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "잘못된 멀티파트 완료 요청",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "403", description = "접근 권한 없음",
+                    content = {@Content(mediaType = "application/json")}
+            )
+    })
+    ResponseEntity<SuccessResponse<Void>> completeContentsUpload(
+            @Parameter(description = "대상 콘텐츠 ID", required = true, example = "1")
+            @PathVariable("contentsId") Long contentsId,
+
+            @Parameter(description = "멀티파트 업로드 완료 요청 바디", required = true)
+            @Valid @RequestBody MultipartUploadCompleteRequest request
+    );
+
+    @Operation(
+            summary = "콘텐츠 멀티파트 업로드 URL 조회",
+            description = "콘텐츠 원본 영상 멀티파트 업로드용 presigned URL을 페이지 단위로 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "멀티파트 업로드 URL 조회 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = PageResponse.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "잘못된 요청 파라미터",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "403", description = "접근 권한 없음",
+                    content = {@Content(mediaType = "application/json")}
+            )
+    })
+    ResponseEntity<SuccessResponse<PageResponse<MultipartUploadPartUrlResponse>>> getContentsUploadPartUrls(
+            @Parameter(description = "대상 콘텐츠 ID", required = true, example = "1")
+            @PathVariable("contentsId") Long contentsId,
+
+            @Parameter(description = "S3 object key", required = true, example = "contents/1/origin/video.mp4")
+            @RequestParam("objectKey") String objectKey,
+
+            @Parameter(description = "S3 multipart upload ID", required = true)
+            @RequestParam("uploadId") String uploadId,
+
+            @Parameter(description = "페이지 번호(0부터 시작)", required = true, example = "0")
+            @RequestParam(value = "page", defaultValue = "0") Integer page,
+
+            @Parameter(description = "페이지 크기", required = true, example = "100")
+            @RequestParam(value = "size", defaultValue = "100") Integer size
     );
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/controller/BackOfficeContentsController.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/controller/BackOfficeContentsController.java
@@ -6,6 +6,9 @@ import com.ott.api_admin.content.dto.response.ContentsDetailResponse;
 import com.ott.api_admin.content.dto.response.ContentsListResponse;
 import com.ott.api_admin.content.dto.response.ContentsUpdateResponse;
 import com.ott.api_admin.content.dto.response.ContentsUploadResponse;
+import com.ott.api_admin.upload.dto.request.MultipartUploadCompleteRequest;
+import com.ott.api_admin.upload.dto.response.MultipartUploadPartUrlResponse;
+import com.ott.api_admin.upload.support.UploadHelper;
 import com.ott.api_admin.content.service.BackOfficeContentsService;
 import com.ott.common.web.response.PageResponse;
 import com.ott.common.web.response.SuccessResponse;
@@ -69,5 +72,34 @@ public class BackOfficeContentsController implements BackOfficeContentsApi {
             @Valid @RequestBody ContentsUpdateRequest request
     ) {
         return ResponseEntity.ok(SuccessResponse.of(backOfficeContentsService.updateContentsUpload(contentsId, request)));
+    }
+
+    @PostMapping("/{contentsId}/upload/complete")
+    public ResponseEntity<SuccessResponse<Void>> completeContentsUpload(
+            @PathVariable("contentsId") Long contentsId,
+            @Valid @RequestBody MultipartUploadCompleteRequest request
+    ) {
+        backOfficeContentsService.completeContentsOriginUpload(
+                contentsId,
+                request.objectKey(),
+                request.uploadId(),
+                request.parts().stream()
+                        .map(part -> new UploadHelper.MultipartPartETag(part.partNumber(), part.eTag()))
+                        .toList()
+        );
+        return ResponseEntity.ok(SuccessResponse.of(null));
+    }
+
+    @GetMapping("/{contentsId}/upload/parts")
+    public ResponseEntity<SuccessResponse<PageResponse<MultipartUploadPartUrlResponse>>> getContentsUploadPartUrls(
+            @PathVariable("contentsId") Long contentsId,
+            @RequestParam("objectKey") String objectKey,
+            @RequestParam("uploadId") String uploadId,
+            @RequestParam(value = "page", defaultValue = "0") Integer page,
+            @RequestParam(value = "size", defaultValue = "100") Integer size
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.of(backOfficeContentsService.getContentsOriginUploadPartUrls(contentsId, objectKey, uploadId, page, size))
+        );
     }
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/controller/BackOfficeContentsController.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/controller/BackOfficeContentsController.java
@@ -74,6 +74,7 @@ public class BackOfficeContentsController implements BackOfficeContentsApi {
         return ResponseEntity.ok(SuccessResponse.of(backOfficeContentsService.updateContentsUpload(contentsId, request)));
     }
 
+    @Override
     @PostMapping("/{contentsId}/upload/complete")
     public ResponseEntity<SuccessResponse<Void>> completeContentsUpload(
             @PathVariable("contentsId") Long contentsId,
@@ -89,7 +90,7 @@ public class BackOfficeContentsController implements BackOfficeContentsApi {
         );
         return ResponseEntity.ok(SuccessResponse.of(null));
     }
-
+    @Override
     @GetMapping("/{contentsId}/upload/parts")
     public ResponseEntity<SuccessResponse<PageResponse<MultipartUploadPartUrlResponse>>> getContentsUploadPartUrls(
             @PathVariable("contentsId") Long contentsId,

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/dto/request/ContentsUploadRequest.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/dto/request/ContentsUploadRequest.java
@@ -42,10 +42,12 @@ public record ContentsUploadRequest(
 
         @Schema(type = "Integer", description = "영상 길이(초)", example = "3600")
         @PositiveOrZero
+        @NotNull
         Integer duration,
 
         @Schema(type = "Integer", description = "영상 크기(KB)", example = "512000")
         @PositiveOrZero
+        @NotNull
         Integer videoSize,
 
         @Schema(type = "String", description = "포스터 원본 파일명", example = "poster.jpg")

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/dto/response/ContentsUploadResponse.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/dto/response/ContentsUploadResponse.java
@@ -25,7 +25,13 @@ public record ContentsUploadResponse(
         @Schema(type = "String", description = "썸네일 업로드용 사전 서명 URL")
         String thumbnailUploadUrl,
 
-        @Schema(type = "String", description = "원본 영상 업로드용 사전 서명 URL")
-        String originUploadUrl
+        @Schema(type = "String", description = "S3 멀티파트 업로드 ID")
+        String originUploadId,
+
+        @Schema(type = "Integer", description = "멀티파트 업로드 : 파트 갯수", example = "800")
+        int originTotalPartCount,
+
+        @Schema(type = "Long", description = "파트별 크기", example = "16777216   <-(16mb)")
+        long originPartSizeBytes
 ) {
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/mapper/BackOfficeContentsMapper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/mapper/BackOfficeContentsMapper.java
@@ -56,7 +56,9 @@ public class BackOfficeContentsMapper {
             String masterPlaylistObjectKey,
             String posterUploadUrl,
             String thumbnailUploadUrl,
-            String originUploadUrl
+            String originUploadId,
+            int originTotalPartCount,
+            long originPartSizeBytes
     ) {
         return new ContentsUploadResponse(
                 contentsId,
@@ -66,7 +68,9 @@ public class BackOfficeContentsMapper {
                 masterPlaylistObjectKey,
                 posterUploadUrl,
                 thumbnailUploadUrl,
-                originUploadUrl
+                originUploadId,
+                originTotalPartCount,
+                originPartSizeBytes
         );
     }
 

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
@@ -206,7 +206,8 @@ public class BackOfficeContentsService {
                 ErrorCode.CONTENTS_ORIGIN_OBJECT_KEY_MISMATCH
         );
 
-        uploadHelper.completeMultipartUpload(objectKey, uploadId, parts);
+        int totalPartCount = uploadHelper.getMultipartPartCount(contents.getVideoSize());
+        uploadHelper.completeMultipartUpload(objectKey, uploadId, totalPartCount, parts);
     }
 
     @Transactional(readOnly = true)

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
@@ -4,10 +4,10 @@ import com.ott.api_admin.content.dto.request.ContentsUploadRequest;
 import com.ott.api_admin.content.dto.request.ContentsUpdateRequest;
 import com.ott.api_admin.content.dto.response.ContentsDetailResponse;
 import com.ott.api_admin.content.dto.response.ContentsListResponse;
-import com.ott.api_admin.content.dto.response.ContentsUpdateResponse;
 import com.ott.api_admin.content.dto.response.ContentsUploadResponse;
-import com.ott.api_admin.upload.dto.response.MultipartUploadPartUrlResponse;
+import com.ott.api_admin.content.dto.response.ContentsUpdateResponse;
 import com.ott.api_admin.content.mapper.BackOfficeContentsMapper;
+import com.ott.api_admin.upload.dto.response.MultipartUploadPartUrlResponse;
 import com.ott.api_admin.upload.support.MediaTagLinker;
 import com.ott.api_admin.upload.support.UploadHelper;
 import com.ott.common.web.exception.BusinessException;
@@ -26,6 +26,7 @@ import com.ott.domain.member.domain.Member;
 import com.ott.domain.series.domain.Series;
 import com.ott.domain.series.repository.SeriesRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -36,6 +37,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class BackOfficeContentsService {
 
     private final BackOfficeContentsMapper backOfficeContentsMapper;
@@ -134,38 +136,57 @@ public class BackOfficeContentsService {
         );
 
         Long contentsId = contents.getId();
-        UploadHelper.MediaCreateUploadResult mediaCreateUploadResult = uploadHelper.prepareMediaCreate(
-                "contents",
-                contentsId,
-                request.posterFileName(),
-                request.thumbnailFileName(),
-                request.originFileName(),
-                request.videoSize()
-        );
 
-        media.updateImageKeys(
-                mediaCreateUploadResult.posterObjectUrl(),
-                mediaCreateUploadResult.thumbnailObjectUrl()
-        );
-        contents.updateStorageKeys(
-                mediaCreateUploadResult.originObjectUrl(),
-                mediaCreateUploadResult.masterPlaylistObjectUrl()
-        );
+        UploadHelper.MediaCreateUploadResult mediaCreateUploadResult = null;
+        try {
+            mediaCreateUploadResult = uploadHelper.prepareMediaCreate(
+                    "contents",
+                    contentsId,
+                    request.posterFileName(),
+                    request.thumbnailFileName(),
+                    request.originFileName(),
+                    request.videoSize()
+            );
 
-        mediaTagLinker.linkTags(media, request.categoryId(), request.tagIdList());
+            media.updateImageKeys(
+                    mediaCreateUploadResult.posterObjectUrl(),
+                    mediaCreateUploadResult.thumbnailObjectUrl()
+            );
+            contents.updateStorageKeys(
+                    mediaCreateUploadResult.originObjectUrl(),
+                    mediaCreateUploadResult.masterPlaylistObjectUrl()
+            );
 
-        return backOfficeContentsMapper.toContentsUploadResponse(
-                contentsId,
-                mediaCreateUploadResult.posterObjectKey(),
-                mediaCreateUploadResult.thumbnailObjectKey(),
-                mediaCreateUploadResult.originObjectKey(),
-                mediaCreateUploadResult.masterPlaylistObjectKey(),
-                mediaCreateUploadResult.posterUploadUrl(),
-                mediaCreateUploadResult.thumbnailUploadUrl(),
-                mediaCreateUploadResult.originUploadId(),
-                mediaCreateUploadResult.originTotalPartCount(),
-                mediaCreateUploadResult.originPartSizeBytes()
-        );
+            mediaTagLinker.linkTags(media, request.categoryId(), request.tagIdList());
+
+            return backOfficeContentsMapper.toContentsUploadResponse(
+                    contentsId,
+                    mediaCreateUploadResult.posterObjectKey(),
+                    mediaCreateUploadResult.thumbnailObjectKey(),
+                    mediaCreateUploadResult.originObjectKey(),
+                    mediaCreateUploadResult.masterPlaylistObjectKey(),
+                    mediaCreateUploadResult.posterUploadUrl(),
+                    mediaCreateUploadResult.thumbnailUploadUrl(),
+                    mediaCreateUploadResult.originUploadId(),
+                    mediaCreateUploadResult.originTotalPartCount(),
+                    mediaCreateUploadResult.originPartSizeBytes()
+            );
+        } catch (RuntimeException ex) {
+            if (mediaCreateUploadResult != null) {
+                try {
+                    uploadHelper.abortMultipartUpload(
+                            mediaCreateUploadResult.originObjectKey(),
+                            mediaCreateUploadResult.originUploadId()
+                    );
+                } catch (Exception abortEx) {
+                    log.warn("Failed to abort multipart upload. objectKey={}, uploadId={}",
+                            mediaCreateUploadResult.originObjectKey(),
+                            mediaCreateUploadResult.originUploadId(),
+                            abortEx);
+                }
+            }
+            throw ex;
+        }
     }
 
     @Transactional(readOnly = true)
@@ -173,7 +194,7 @@ public class BackOfficeContentsService {
         Contents contents = contentsRepository.findById(contentsId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
 
-        uploadHelper.checkObjectKeyMatchesOriginUrl(
+        uploadHelper.validateOriginObjectKey(
                 objectKey,
                 contents.getOriginUrl(),
                 ErrorCode.CONTENTS_ORIGIN_OBJECT_KEY_MISMATCH
@@ -193,14 +214,14 @@ public class BackOfficeContentsService {
         Contents contents = contentsRepository.findById(contentsId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
 
-        uploadHelper.checkObjectKeyMatchesOriginUrl(
+        uploadHelper.validateOriginObjectKey(
                 objectKey,
                 contents.getOriginUrl(),
                 ErrorCode.CONTENTS_ORIGIN_OBJECT_KEY_MISMATCH
         );
 
-        int totalPartCount = uploadHelper.calculateMultipartPartCount(contents.getVideoSize());
-        PageResponse<UploadHelper.MultipartUploadPartUrl> partUrlPage = uploadHelper.getMultipartUploadPartUrlsPage(
+        int totalPartCount = uploadHelper.getMultipartPartCount(contents.getVideoSize());
+        PageResponse<UploadHelper.MultipartUploadPartUrl> partUrlPage = uploadHelper.getMultipartPartUrls(
                 objectKey,
                 uploadId,
                 totalPartCount,

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
@@ -6,6 +6,7 @@ import com.ott.api_admin.content.dto.response.ContentsDetailResponse;
 import com.ott.api_admin.content.dto.response.ContentsListResponse;
 import com.ott.api_admin.content.dto.response.ContentsUpdateResponse;
 import com.ott.api_admin.content.dto.response.ContentsUploadResponse;
+import com.ott.api_admin.upload.dto.response.MultipartUploadPartUrlResponse;
 import com.ott.api_admin.content.mapper.BackOfficeContentsMapper;
 import com.ott.api_admin.upload.support.MediaTagLinker;
 import com.ott.api_admin.upload.support.UploadHelper;
@@ -134,7 +135,12 @@ public class BackOfficeContentsService {
 
         Long contentsId = contents.getId();
         UploadHelper.MediaCreateUploadResult mediaCreateUploadResult = uploadHelper.prepareMediaCreate(
-                "contents", contentsId, request.posterFileName(), request.thumbnailFileName(), request.originFileName()
+                "contents",
+                contentsId,
+                request.posterFileName(),
+                request.thumbnailFileName(),
+                request.originFileName(),
+                request.videoSize()
         );
 
         media.updateImageKeys(
@@ -156,8 +162,57 @@ public class BackOfficeContentsService {
                 mediaCreateUploadResult.masterPlaylistObjectKey(),
                 mediaCreateUploadResult.posterUploadUrl(),
                 mediaCreateUploadResult.thumbnailUploadUrl(),
-                mediaCreateUploadResult.originUploadUrl()
+                mediaCreateUploadResult.originUploadId(),
+                mediaCreateUploadResult.originTotalPartCount(),
+                mediaCreateUploadResult.originPartSizeBytes()
         );
+    }
+
+    @Transactional(readOnly = true)
+    public void completeContentsOriginUpload(Long contentsId, String objectKey, String uploadId, List<UploadHelper.MultipartPartETag> parts) {
+        Contents contents = contentsRepository.findById(contentsId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
+
+        uploadHelper.checkObjectKeyMatchesOriginUrl(
+                objectKey,
+                contents.getOriginUrl(),
+                ErrorCode.CONTENTS_ORIGIN_OBJECT_KEY_MISMATCH
+        );
+
+        uploadHelper.completeMultipartUpload(objectKey, uploadId, parts);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<MultipartUploadPartUrlResponse> getContentsOriginUploadPartUrls(
+            Long contentsId,
+            String objectKey,
+            String uploadId,
+            Integer page,
+            Integer size
+    ) {
+        Contents contents = contentsRepository.findById(contentsId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
+
+        uploadHelper.checkObjectKeyMatchesOriginUrl(
+                objectKey,
+                contents.getOriginUrl(),
+                ErrorCode.CONTENTS_ORIGIN_OBJECT_KEY_MISMATCH
+        );
+
+        int totalPartCount = uploadHelper.calculateMultipartPartCount(contents.getVideoSize());
+        PageResponse<UploadHelper.MultipartUploadPartUrl> partUrlPage = uploadHelper.getMultipartUploadPartUrlsPage(
+                objectKey,
+                uploadId,
+                totalPartCount,
+                page,
+                size
+        );
+
+        List<MultipartUploadPartUrlResponse> dataList = partUrlPage.getDataList().stream()
+                .map(part -> new MultipartUploadPartUrlResponse(part.partNumber(), part.uploadUrl()))
+                .toList();
+
+        return PageResponse.toPageResponse(partUrlPage.getPageInfo(), dataList);
     }
 
     @Transactional

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/controller/BackOfficeShortFormApi.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/controller/BackOfficeShortFormApi.java
@@ -1,12 +1,14 @@
 package com.ott.api_admin.shortform.controller;
 
+import com.ott.api_admin.shortform.dto.request.ShortFormUpdateRequest;
+import com.ott.api_admin.shortform.dto.request.ShortFormUploadRequest;
 import com.ott.api_admin.shortform.dto.response.OriginMediaTitleListResponse;
 import com.ott.api_admin.shortform.dto.response.ShortFormDetailResponse;
 import com.ott.api_admin.shortform.dto.response.ShortFormListResponse;
 import com.ott.api_admin.shortform.dto.response.ShortFormUpdateResponse;
 import com.ott.api_admin.shortform.dto.response.ShortFormUploadResponse;
-import com.ott.api_admin.shortform.dto.request.ShortFormUpdateRequest;
-import com.ott.api_admin.shortform.dto.request.ShortFormUploadRequest;
+import com.ott.api_admin.upload.dto.request.MultipartUploadCompleteRequest;
+import com.ott.api_admin.upload.dto.response.MultipartUploadPartUrlResponse;
 import com.ott.common.web.exception.ErrorResponse;
 import com.ott.common.web.response.PageResponse;
 import com.ott.common.web.response.SuccessResponse;
@@ -134,6 +136,69 @@ public interface BackOfficeShortFormApi {
 
             @Parameter(description = "ShortFormUpdateRequest 참고해주세요.", required = true)
             @Valid @RequestBody ShortFormUpdateRequest request,
+            Authentication authentication
+    );
+
+    @Operation(
+            summary = "숏폼 멀티파트 업로드 완료",
+            description = "objectKey, uploadId, 업로드된 part eTag 목록을 사용해 숏폼 원본 영상의 S3 멀티파트 업로드를 완료합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "멀티파트 업로드 완료 성공",
+                    content = {@Content(mediaType = "application/json")}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "잘못된 멀티파트 완료 요청",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "403", description = "접근 권한 없음",
+                    content = {@Content(mediaType = "application/json")}
+            )
+    })
+    ResponseEntity<SuccessResponse<Void>> completeShortFormUpload(
+            @Parameter(description = "대상 숏폼 ID", required = true, example = "1")
+            @PathVariable("shortformId") Long shortformId,
+
+            @Parameter(description = "멀티파트 업로드 완료 요청 바디", required = true)
+            @Valid @RequestBody MultipartUploadCompleteRequest request,
+            Authentication authentication
+    );
+
+    @Operation(
+            summary = "숏폼 멀티파트 업로드 URL 조회",
+            description = "숏폼 원본 영상 멀티파트 업로드용 presigned URL을 페이지 단위로 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "멀티파트 업로드 URL 조회 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = PageResponse.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "잘못된 요청 파라미터",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "403", description = "접근 권한 없음",
+                    content = {@Content(mediaType = "application/json")}
+            )
+    })
+    ResponseEntity<SuccessResponse<PageResponse<MultipartUploadPartUrlResponse>>> getShortFormUploadPartUrls(
+            @Parameter(description = "대상 숏폼 ID", required = true, example = "1")
+            @PathVariable("shortformId") Long shortformId,
+
+            @Parameter(description = "S3 object key", required = true, example = "short-forms/1/origin/video.mp4")
+            @RequestParam("objectKey") String objectKey,
+
+            @Parameter(description = "S3 multipart upload ID", required = true)
+            @RequestParam("uploadId") String uploadId,
+
+            @Parameter(description = "페이지 번호(0부터 시작)", required = true, example = "0")
+            @RequestParam(value = "page", defaultValue = "0") Integer page,
+
+            @Parameter(description = "페이지 크기", required = true, example = "100")
+            @RequestParam(value = "size", defaultValue = "100") Integer size,
             Authentication authentication
     );
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/controller/BackOfficeShortFormController.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/controller/BackOfficeShortFormController.java
@@ -5,8 +5,11 @@ import com.ott.api_admin.shortform.dto.response.ShortFormDetailResponse;
 import com.ott.api_admin.shortform.dto.response.ShortFormListResponse;
 import com.ott.api_admin.shortform.dto.response.ShortFormUpdateResponse;
 import com.ott.api_admin.shortform.dto.response.ShortFormUploadResponse;
+import com.ott.api_admin.upload.dto.request.MultipartUploadCompleteRequest;
+import com.ott.api_admin.upload.dto.response.MultipartUploadPartUrlResponse;
 import com.ott.api_admin.shortform.dto.request.ShortFormUpdateRequest;
 import com.ott.api_admin.shortform.dto.request.ShortFormUploadRequest;
+import com.ott.api_admin.upload.support.UploadHelper;
 import com.ott.api_admin.shortform.service.BackOfficeShortFormService;
 import com.ott.common.web.response.PageResponse;
 import com.ott.common.web.response.SuccessResponse;
@@ -86,5 +89,46 @@ public class BackOfficeShortFormController implements BackOfficeShortFormApi {
             Authentication authentication
     ) {
         return ResponseEntity.ok(SuccessResponse.of(backOfficeShortFormService.updateShortFormUpload(shortformId, request, authentication)));
+    }
+
+    @PostMapping("/{shortformId}/upload/complete")
+    public ResponseEntity<SuccessResponse<Void>> completeShortFormUpload(
+            @PathVariable("shortformId") Long shortformId,
+            @Valid @RequestBody MultipartUploadCompleteRequest request,
+            Authentication authentication
+    ) {
+        backOfficeShortFormService.completeShortFormOriginUpload(
+                shortformId,
+                request.objectKey(),
+                request.uploadId(),
+                request.parts().stream()
+                        .map(part -> new UploadHelper.MultipartPartETag(part.partNumber(), part.eTag()))
+                        .toList(),
+                authentication
+        );
+        return ResponseEntity.ok(SuccessResponse.of(null));
+    }
+
+    @GetMapping("/{shortformId}/upload/parts")
+    public ResponseEntity<SuccessResponse<PageResponse<MultipartUploadPartUrlResponse>>> getShortFormUploadPartUrls(
+            @PathVariable("shortformId") Long shortformId,
+            @RequestParam("objectKey") String objectKey,
+            @RequestParam("uploadId") String uploadId,
+            @RequestParam(value = "page", defaultValue = "0") Integer page,
+            @RequestParam(value = "size", defaultValue = "100") Integer size,
+            Authentication authentication
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        backOfficeShortFormService.getShortFormOriginUploadPartUrls(
+                                shortformId,
+                                objectKey,
+                                uploadId,
+                                page,
+                                size,
+                                authentication
+                        )
+                )
+        );
     }
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/controller/BackOfficeShortFormController.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/controller/BackOfficeShortFormController.java
@@ -91,6 +91,7 @@ public class BackOfficeShortFormController implements BackOfficeShortFormApi {
         return ResponseEntity.ok(SuccessResponse.of(backOfficeShortFormService.updateShortFormUpload(shortformId, request, authentication)));
     }
 
+    @Override
     @PostMapping("/{shortformId}/upload/complete")
     public ResponseEntity<SuccessResponse<Void>> completeShortFormUpload(
             @PathVariable("shortformId") Long shortformId,
@@ -109,6 +110,7 @@ public class BackOfficeShortFormController implements BackOfficeShortFormApi {
         return ResponseEntity.ok(SuccessResponse.of(null));
     }
 
+    @Override
     @GetMapping("/{shortformId}/upload/parts")
     public ResponseEntity<SuccessResponse<PageResponse<MultipartUploadPartUrlResponse>>> getShortFormUploadPartUrls(
             @PathVariable("shortformId") Long shortformId,

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/dto/request/ShortFormUploadRequest.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/dto/request/ShortFormUploadRequest.java
@@ -31,10 +31,12 @@ public record ShortFormUploadRequest(
 
         @Schema(type = "Integer", description = "영상 길이(초)", example = "60")
         @PositiveOrZero
+        @NotNull
         Integer duration,
 
         @Schema(type = "Integer", description = "영상 크기(KB)", example = "10240")
         @PositiveOrZero
+        @NotNull
         Integer videoSize,
 
         @Schema(type = "String", description = "포스터 원본 파일명", example = "poster.jpg")

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/dto/response/ShortFormUploadResponse.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/dto/response/ShortFormUploadResponse.java
@@ -25,7 +25,13 @@ public record ShortFormUploadResponse(
         @Schema(type = "String", description = "썸네일 업로드용 사전 서명 URL")
         String thumbnailUploadUrl,
 
-        @Schema(type = "String", description = "원본 영상 업로드용 사전 서명 URL")
-        String originUploadUrl
+        @Schema(type = "String", description = "S3 멀티파트 업로드 ID", example  = "2~Qf8xq2nM8YJf4l9Yxj2k3bA7rTz9Lk8aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789")
+        String originUploadId,
+
+        @Schema(type = "Integer", description = "멀티파트 업로드 : 파트 갯수", example = "800")
+        int originTotalPartCount,
+
+        @Schema(type = "Long", description = "파트별 크기", example = "16777216   <-(16mb)")
+        long originPartSizeBytes
 ) {
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/mapper/BackOfficeShortFormMapper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/mapper/BackOfficeShortFormMapper.java
@@ -80,7 +80,9 @@ public class BackOfficeShortFormMapper {
             String masterPlaylistObjectKey,
             String posterUploadUrl,
             String thumbnailUploadUrl,
-            String originUploadUrl
+            String originUploadId,
+            int originTotalPartCount,
+            long originPartSizeBytes
     ) {
         return new ShortFormUploadResponse(
                 shortFormId,
@@ -90,7 +92,9 @@ public class BackOfficeShortFormMapper {
                 masterPlaylistObjectKey,
                 posterUploadUrl,
                 thumbnailUploadUrl,
-                originUploadUrl
+                originUploadId,
+                originTotalPartCount,
+                originPartSizeBytes
         );
     }
 

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/service/BackOfficeShortFormService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/service/BackOfficeShortFormService.java
@@ -284,7 +284,8 @@ public class BackOfficeShortFormService {
                 ErrorCode.SHORTFORM_ORIGIN_OBJECT_KEY_MISMATCH
         );
 
-        uploadHelper.completeMultipartUpload(objectKey, uploadId, parts);
+        int totalPartCount = uploadHelper.getMultipartPartCount(shortForm.getVideoSize());
+        uploadHelper.completeMultipartUpload(objectKey, uploadId, totalPartCount, parts);
     }
 
     @Transactional(readOnly = true)

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/service/BackOfficeShortFormService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/service/BackOfficeShortFormService.java
@@ -29,6 +29,7 @@ import com.ott.domain.series.repository.SeriesRepository;
 import com.ott.domain.short_form.domain.ShortForm;
 import com.ott.domain.short_form.repository.ShortFormRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -43,365 +44,380 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class BackOfficeShortFormService {
 
-        private final BackOfficeShortFormMapper backOfficeShortFormMapper;
+    private final BackOfficeShortFormMapper backOfficeShortFormMapper;
 
-        private final MediaRepository mediaRepository;
-        private final MediaTagRepository mediaTagRepository;
-        private final SeriesRepository seriesRepository;
-        private final ContentsRepository contentsRepository;
-        private final ShortFormRepository shortFormRepository;
-        private final UploadHelper uploadHelper;
+    private final MediaRepository mediaRepository;
+    private final MediaTagRepository mediaTagRepository;
+    private final SeriesRepository seriesRepository;
+    private final ContentsRepository contentsRepository;
+    private final ShortFormRepository shortFormRepository;
+    private final UploadHelper uploadHelper;
 
-        @Transactional(readOnly = true)
-        public PageResponse<ShortFormListResponse> getShortFormList(
-                        Integer page, Integer size, String searchWord, PublicStatus publicStatus,
-                        Authentication authentication) {
-                Pageable pageable = PageRequest.of(page, size);
+    @Transactional(readOnly = true)
+    public PageResponse<ShortFormListResponse> getShortFormList(
+            Integer page, Integer size, String searchWord, PublicStatus publicStatus,
+            Authentication authentication) {
+        Pageable pageable = PageRequest.of(page, size);
 
-                Long memberId = (Long) authentication.getPrincipal();
-                boolean isEditor = authentication.getAuthorities().stream()
-                                .anyMatch(authority -> Role.EDITOR.getKey().equals(authority.getAuthority()));
-                Long uploaderId = null;
+        Long memberId = (Long) authentication.getPrincipal();
+        boolean isEditor = authentication.getAuthorities().stream()
+                .anyMatch(authority -> Role.EDITOR.getKey().equals(authority.getAuthority()));
+        Long uploaderId = null;
 
-                if (isEditor) {
-                        uploaderId = memberId;
-                }
-
-                Page<Media> mediaPage = mediaRepository
-                                .findMediaListByMediaTypeAndSearchWordAndPublicStatusAndUploaderId(
-                                                pageable, MediaType.SHORT_FORM, searchWord, publicStatus, uploaderId);
-
-                List<ShortFormListResponse> responseList = mediaPage.getContent().stream()
-                                .map(backOfficeShortFormMapper::toShortFormListResponse)
-                                .toList();
-
-                PageInfo pageInfo = PageInfo.toPageInfo(
-                                mediaPage.getNumber(),
-                                mediaPage.getTotalPages(),
-                                mediaPage.getSize());
-
-                return PageResponse.toPageResponse(pageInfo, responseList);
+        if (isEditor) {
+            uploaderId = memberId;
         }
 
-        @Transactional(readOnly = true)
-        public PageResponse<OriginMediaTitleListResponse> getOriginMediaTitle(Integer page, Integer size,
-                        String searchWord) {
-                Pageable pageable = PageRequest.of(page, size);
+        Page<Media> mediaPage = mediaRepository
+                .findMediaListByMediaTypeAndSearchWordAndPublicStatusAndUploaderId(
+                        pageable, MediaType.SHORT_FORM, searchWord, publicStatus, uploaderId);
 
-                Page<Media> mediaPage = mediaRepository.findOriginMediaListBySearchWord(pageable, searchWord);
+        List<ShortFormListResponse> responseList = mediaPage.getContent().stream()
+                .map(backOfficeShortFormMapper::toShortFormListResponse)
+                .toList();
 
-                List<Media> mediaList = mediaPage.getContent();
+        PageInfo pageInfo = PageInfo.toPageInfo(
+                mediaPage.getNumber(),
+                mediaPage.getTotalPages(),
+                mediaPage.getSize());
 
-                List<Long> seriesMediaIdList = mediaList.stream()
-                                .filter(m -> m.getMediaType() == MediaType.SERIES)
-                                .map(Media::getId)
-                                .toList();
+        return PageResponse.toPageResponse(pageInfo, responseList);
+    }
 
-                List<Long> contentsMediaIdList = mediaList.stream()
-                                .filter(m -> m.getMediaType() == MediaType.CONTENTS)
-                                .map(Media::getId)
-                                .toList();
+    @Transactional(readOnly = true)
+    public PageResponse<OriginMediaTitleListResponse> getOriginMediaTitle(Integer page, Integer size, String searchWord) {
+        Pageable pageable = PageRequest.of(page, size);
 
-                Map<Long, Long> seriesIdByMediaId = seriesRepository.findAllByMediaIdIn(seriesMediaIdList).stream()
-                                .collect(Collectors.toMap(s -> s.getMedia().getId(), Series::getId));
+        Page<Media> mediaPage = mediaRepository.findOriginMediaListBySearchWord(pageable, searchWord);
 
-                Map<Long, Long> contentsIdByMediaId = contentsRepository.findAllByMediaIdIn(contentsMediaIdList)
-                                .stream()
-                                .collect(Collectors.toMap(c -> c.getMedia().getId(), Contents::getId));
+        List<Media> mediaList = mediaPage.getContent();
 
-                List<OriginMediaTitleListResponse> responseList = mediaList.stream()
-                                .map(m -> backOfficeShortFormMapper.toOriginMediaTitleListResponse(m, seriesIdByMediaId,
-                                                contentsIdByMediaId))
-                                .toList();
+        List<Long> seriesMediaIdList = mediaList.stream()
+                .filter(m -> m.getMediaType() == MediaType.SERIES)
+                .map(Media::getId)
+                .toList();
 
-                PageInfo pageInfo = PageInfo.toPageInfo(
-                                mediaPage.getNumber(),
-                                mediaPage.getTotalPages(),
-                                mediaPage.getSize());
+        List<Long> contentsMediaIdList = mediaList.stream()
+                .filter(m -> m.getMediaType() == MediaType.CONTENTS)
+                .map(Media::getId)
+                .toList();
 
-                return PageResponse.toPageResponse(pageInfo, responseList);
+        Map<Long, Long> seriesIdByMediaId = seriesRepository.findAllByMediaIdIn(seriesMediaIdList).stream()
+                .collect(Collectors.toMap(s -> s.getMedia().getId(), Series::getId));
+
+        Map<Long, Long> contentsIdByMediaId = contentsRepository.findAllByMediaIdIn(contentsMediaIdList)
+                .stream()
+                .collect(Collectors.toMap(c -> c.getMedia().getId(), Contents::getId));
+
+        List<OriginMediaTitleListResponse> responseList = mediaList.stream()
+                .map(m -> backOfficeShortFormMapper.toOriginMediaTitleListResponse(m, seriesIdByMediaId,
+                        contentsIdByMediaId))
+                .toList();
+
+        PageInfo pageInfo = PageInfo.toPageInfo(
+                mediaPage.getNumber(),
+                mediaPage.getTotalPages(),
+                mediaPage.getSize());
+
+        return PageResponse.toPageResponse(pageInfo, responseList);
+    }
+
+    @Transactional(readOnly = true)
+    public ShortFormDetailResponse getShortFormDetail(Long mediaId, Authentication authentication) {
+        ShortForm shortForm = shortFormRepository.findWithMediaAndUploaderByMediaId(mediaId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
+
+        Long memberId = (Long) authentication.getPrincipal();
+        boolean isEditor = authentication.getAuthorities().stream()
+                .anyMatch(authority -> Role.EDITOR.getKey().equals(authority.getAuthority()));
+
+        Media media = shortForm.getMedia();
+        if (isEditor && !media.getUploader().getId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
-        @Transactional(readOnly = true)
-        public ShortFormDetailResponse getShortFormDetail(Long mediaId, Authentication authentication) {
-                ShortForm shortForm = shortFormRepository.findWithMediaAndUploaderByMediaId(mediaId)
-                                .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
+        String uploaderNickname = media.getUploader().getNickname();
 
-                Long memberId = (Long) authentication.getPrincipal();
-                boolean isEditor = authentication.getAuthorities().stream()
-                                .anyMatch(authority -> Role.EDITOR.getKey().equals(authority.getAuthority()));
-
-                Media media = shortForm.getMedia();
-                if (isEditor && !media.getUploader().getId().equals(memberId)) {
-                        throw new BusinessException(ErrorCode.FORBIDDEN);
-                }
-
-                String uploaderNickname = media.getUploader().getNickname();
-
-                Optional<Media> originMedia = shortForm.findOriginMedia();
-                String originMediaTitle = null;
-                Long originId = null;
-                MediaType originType = null;
-                if (originMedia.isPresent()) {
-                        originMediaTitle = originMedia.get().getTitle();
-                        if (shortForm.getSeries() != null) {
-                                originId = shortForm.getSeries().getId();
-                                originType = MediaType.SERIES;
-                        } else if (shortForm.getContents() != null) {
-                                originId = shortForm.getContents().getId();
-                                originType = MediaType.CONTENTS;
-                        }
-                }
-
-                List<MediaTag> mediaTagList = mediaTagRepository.findWithTagAndCategoryByMediaId(mediaId);
-
-                return backOfficeShortFormMapper.toShortFormDetailResponse(
-                                shortForm,
-                                media,
-                                uploaderNickname,
-                                originMediaTitle,
-                                originId,
-                                originType,
-                                mediaTagList
-                );
+        Optional<Media> originMedia = shortForm.findOriginMedia();
+        String originMediaTitle = null;
+        Long originId = null;
+        MediaType originType = null;
+        if (originMedia.isPresent()) {
+            originMediaTitle = originMedia.get().getTitle();
+            if (shortForm.getSeries() != null) {
+                originId = shortForm.getSeries().getId();
+                originType = MediaType.SERIES;
+            } else if (shortForm.getContents() != null) {
+                originId = shortForm.getContents().getId();
+                originType = MediaType.CONTENTS;
+            }
         }
 
-        @Transactional
-        public ShortFormUploadResponse createShortFormUpload(ShortFormUploadRequest request, Long memberId) {
-                Member uploader = uploadHelper.resolveUploader(memberId);
-                Series series = null;
-                Contents contents = null;
+        List<MediaTag> mediaTagList = mediaTagRepository.findWithTagAndCategoryByMediaId(mediaId);
 
-                if ( request.mediaType().equals(MediaType.SERIES) ) {
-                        series = seriesRepository.findById(request.originId())
-                                .orElseThrow(() -> new BusinessException(ErrorCode.SERIES_NOT_FOUND));
-                } else if ( request.mediaType().equals(MediaType.CONTENTS) ){
-                        contents = resolveContents(request.originId());
-                } else {
-                        throw new BusinessException(ErrorCode.INVALID_SHORTFORM_TARGET);
-                }
+        return backOfficeShortFormMapper.toShortFormDetailResponse(
+                shortForm,
+                media,
+                uploaderNickname,
+                originMediaTitle,
+                originId,
+                originType,
+                mediaTagList
+        );
+    }
 
-                Media media = mediaRepository.save(
-                                Media.builder()
-                                                .uploader(uploader)
-                                                .title(request.title())
-                                                .description(request.description())
-                                                .posterUrl("PENDING")
-                                                .thumbnailUrl("PENDING")
-                                                .bookmarkCount(0L)
-                                                .likesCount(0L)
-                                                .mediaType(MediaType.SHORT_FORM)
-                                                .publicStatus(request.publicStatus())
-                                                .build());
+    @Transactional
+    public ShortFormUploadResponse createShortFormUpload(ShortFormUploadRequest request, Long memberId) {
+        Member uploader = uploadHelper.resolveUploader(memberId);
+        Series series = null;
+        Contents contents = null;
 
-                ShortForm shortForm = shortFormRepository.save(
-                                ShortForm.builder()
-                                                .media(media)
-                                                .series(series)
-                                                .contents(contents)
-                                                .duration(request.duration())
-                                                .videoSize(request.videoSize())
-                                                .originUrl("PENDING")
-                                                .masterPlaylistUrl("PENDING")
-                                                .build());
-
-                Long shortFormId = shortForm.getId();
-                UploadHelper.MediaCreateUploadResult mediaCreateUploadResult = uploadHelper.prepareMediaCreate(
-                                "short-forms",
-                                shortFormId,
-                                request.posterFileName(),
-                                null,
-                                request.originFileName(),
-                                request.videoSize()
-                );
-
-                media.updateImageKeys(
-                                mediaCreateUploadResult.posterObjectUrl(),
-                                mediaCreateUploadResult.thumbnailObjectUrl());
-                shortForm.updateStorageKeys(
-                                mediaCreateUploadResult.originObjectUrl(),
-                                mediaCreateUploadResult.masterPlaylistObjectUrl());
-
-                Long originMediaId = resolveOriginMediaId(series, contents);
-                inheritOriginMediaTags(media, originMediaId);
-
-                return backOfficeShortFormMapper.toShortFormUploadResponse(
-                                shortFormId,
-                                mediaCreateUploadResult.posterObjectKey(),
-                                mediaCreateUploadResult.thumbnailObjectKey(),
-                                mediaCreateUploadResult.originObjectKey(),
-                                mediaCreateUploadResult.masterPlaylistObjectKey(),
-                                mediaCreateUploadResult.posterUploadUrl(),
-                                mediaCreateUploadResult.thumbnailUploadUrl(),
-                                mediaCreateUploadResult.originUploadId(),
-                                mediaCreateUploadResult.originTotalPartCount(),
-                                mediaCreateUploadResult.originPartSizeBytes());
+        if (request.mediaType().equals(MediaType.SERIES)) {
+            series = seriesRepository.findById(request.originId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.SERIES_NOT_FOUND));
+        } else if (request.mediaType().equals(MediaType.CONTENTS)) {
+            contents = resolveContents(request.originId());
+        } else {
+            throw new BusinessException(ErrorCode.INVALID_SHORTFORM_TARGET);
         }
 
-        @Transactional(readOnly = true)
-        public void completeShortFormOriginUpload(
-                        Long shortFormId,
-                        String objectKey,
-                        String uploadId,
-                        List<UploadHelper.MultipartPartETag> parts,
-                        Authentication authentication
-        ) {
-                ShortForm shortForm = shortFormRepository.findWithMediaAndUploaderByShortFormId(shortFormId)
-                                .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
+        Media media = mediaRepository.save(
+                Media.builder()
+                        .uploader(uploader)
+                        .title(request.title())
+                        .description(request.description())
+                        .posterUrl("PENDING")
+                        .thumbnailUrl("PENDING")
+                        .bookmarkCount(0L)
+                        .likesCount(0L)
+                        .mediaType(MediaType.SHORT_FORM)
+                        .publicStatus(request.publicStatus())
+                        .build());
 
-                Media media = shortForm.getMedia();
-                Long memberId = (Long) authentication.getPrincipal();
-                boolean isEditor = authentication.getAuthorities().stream()
-                                .anyMatch(authority -> Role.EDITOR.getKey().equals(authority.getAuthority()));
-                if (isEditor && !media.getUploader().getId().equals(memberId)) {
-                        throw new BusinessException(ErrorCode.FORBIDDEN);
+        ShortForm shortForm = shortFormRepository.save(
+                ShortForm.builder()
+                        .media(media)
+                        .series(series)
+                        .contents(contents)
+                        .duration(request.duration())
+                        .videoSize(request.videoSize())
+                        .originUrl("PENDING")
+                        .masterPlaylistUrl("PENDING")
+                        .build());
+
+        Long shortFormId = shortForm.getId();
+        UploadHelper.MediaCreateUploadResult mediaCreateUploadResult = null;
+        try {
+            mediaCreateUploadResult = uploadHelper.prepareMediaCreate(
+                    "short-forms",
+                    shortFormId,
+                    request.posterFileName(),
+                    null,
+                    request.originFileName(),
+                    request.videoSize()
+            );
+
+            media.updateImageKeys(
+                    mediaCreateUploadResult.posterObjectUrl(),
+                    mediaCreateUploadResult.thumbnailObjectUrl());
+            shortForm.updateStorageKeys(
+                    mediaCreateUploadResult.originObjectUrl(),
+                    mediaCreateUploadResult.masterPlaylistObjectUrl());
+
+            Long originMediaId = resolveOriginMediaId(series, contents);
+            inheritOriginMediaTags(media, originMediaId);
+
+            return backOfficeShortFormMapper.toShortFormUploadResponse(
+                    shortFormId,
+                    mediaCreateUploadResult.posterObjectKey(),
+                    mediaCreateUploadResult.thumbnailObjectKey(),
+                    mediaCreateUploadResult.originObjectKey(),
+                    mediaCreateUploadResult.masterPlaylistObjectKey(),
+                    mediaCreateUploadResult.posterUploadUrl(),
+                    mediaCreateUploadResult.thumbnailUploadUrl(),
+                    mediaCreateUploadResult.originUploadId(),
+                    mediaCreateUploadResult.originTotalPartCount(),
+                    mediaCreateUploadResult.originPartSizeBytes());
+        } catch (RuntimeException ex) {
+            if (mediaCreateUploadResult != null) {
+                try {
+                    uploadHelper.abortMultipartUpload(
+                            mediaCreateUploadResult.originObjectKey(),
+                            mediaCreateUploadResult.originUploadId()
+                    );
+                } catch (Exception abortEx) {
+                    log.warn("Failed to abort multipart upload. objectKey={}, uploadId={}",
+                            mediaCreateUploadResult.originObjectKey(),
+                            mediaCreateUploadResult.originUploadId(),
+                            abortEx);
                 }
+            }
+            throw ex;
+        }
+    }
 
-                uploadHelper.checkObjectKeyMatchesOriginUrl(
-                                objectKey,
-                                shortForm.getOriginUrl(),
-                                ErrorCode.SHORTFORM_ORIGIN_OBJECT_KEY_MISMATCH
-                );
+    @Transactional(readOnly = true)
+    public void completeShortFormOriginUpload(
+            Long shortFormId,
+            String objectKey,
+            String uploadId,
+            List<UploadHelper.MultipartPartETag> parts,
+            Authentication authentication
+    ) {
+        ShortForm shortForm = shortFormRepository.findWithMediaAndUploaderByShortFormId(shortFormId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
 
-                uploadHelper.completeMultipartUpload(objectKey, uploadId, parts);
+        Media media = shortForm.getMedia();
+        Long memberId = (Long) authentication.getPrincipal();
+        boolean isEditor = authentication.getAuthorities().stream()
+                .anyMatch(authority -> Role.EDITOR.getKey().equals(authority.getAuthority()));
+        if (isEditor && !media.getUploader().getId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
-        @Transactional(readOnly = true)
-        public PageResponse<MultipartUploadPartUrlResponse> getShortFormOriginUploadPartUrls(
-                        Long shortFormId,
-                        String objectKey,
-                        String uploadId,
-                        Integer page,
-                        Integer size,
-                        Authentication authentication
-        ) {
-                ShortForm shortForm = shortFormRepository.findWithMediaAndUploaderByShortFormId(shortFormId)
-                                .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
+        uploadHelper.validateOriginObjectKey(
+                objectKey,
+                shortForm.getOriginUrl(),
+                ErrorCode.SHORTFORM_ORIGIN_OBJECT_KEY_MISMATCH
+        );
 
-                Media media = shortForm.getMedia();
-                Long memberId = (Long) authentication.getPrincipal();
-                boolean isEditor = authentication.getAuthorities().stream()
-                                .anyMatch(authority -> Role.EDITOR.getKey().equals(authority.getAuthority()));
-                if (isEditor && !media.getUploader().getId().equals(memberId)) {
-                        throw new BusinessException(ErrorCode.FORBIDDEN);
-                }
+        uploadHelper.completeMultipartUpload(objectKey, uploadId, parts);
+    }
 
-                uploadHelper.checkObjectKeyMatchesOriginUrl(
-                                objectKey,
-                                shortForm.getOriginUrl(),
-                                ErrorCode.SHORTFORM_ORIGIN_OBJECT_KEY_MISMATCH
-                );
+    @Transactional(readOnly = true)
+    public PageResponse<MultipartUploadPartUrlResponse> getShortFormOriginUploadPartUrls(
+            Long shortFormId,
+            String objectKey,
+            String uploadId,
+            Integer page,
+            Integer size,
+            Authentication authentication
+    ) {
+        ShortForm shortForm = shortFormRepository.findWithMediaAndUploaderByShortFormId(shortFormId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
 
-                int totalPartCount = uploadHelper.calculateMultipartPartCount(shortForm.getVideoSize());
-                PageResponse<UploadHelper.MultipartUploadPartUrl> partUrlPage = uploadHelper.getMultipartUploadPartUrlsPage(
-                                objectKey,
-                                uploadId,
-                                totalPartCount,
-                                page,
-                                size
-                );
-
-                List<MultipartUploadPartUrlResponse> dataList = partUrlPage.getDataList().stream()
-                                .map(part -> new MultipartUploadPartUrlResponse(part.partNumber(), part.uploadUrl()))
-                                .toList();
-
-                return PageResponse.toPageResponse(partUrlPage.getPageInfo(), dataList);
+        Media media = shortForm.getMedia();
+        Long memberId = (Long) authentication.getPrincipal();
+        boolean isEditor = authentication.getAuthorities().stream()
+                .anyMatch(authority -> Role.EDITOR.getKey().equals(authority.getAuthority()));
+        if (isEditor && !media.getUploader().getId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
-        @Transactional
-        public ShortFormUpdateResponse updateShortFormUpload(Long shortformId, ShortFormUpdateRequest request, Authentication authentication) {
-                ShortForm shortForm = shortFormRepository.findWithMediaAndUploaderByShortFormId(shortformId)
-                                .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
+        uploadHelper.validateOriginObjectKey(
+                objectKey,
+                shortForm.getOriginUrl(),
+                ErrorCode.SHORTFORM_ORIGIN_OBJECT_KEY_MISMATCH
+        );
 
-                Media media = shortForm.getMedia();
-                Long memberId = (Long) authentication.getPrincipal();
-                boolean isEditor = authentication.getAuthorities().stream()
-                                .anyMatch(authority -> Role.EDITOR.getKey().equals(authority.getAuthority()));
-                if (isEditor && !media.getUploader().getId().equals(memberId)) {
-                        throw new BusinessException(ErrorCode.FORBIDDEN);
-                }
+        int totalPartCount = uploadHelper.getMultipartPartCount(shortForm.getVideoSize());
+        PageResponse<UploadHelper.MultipartUploadPartUrl> partUrlPage = uploadHelper.getMultipartPartUrls(
+                objectKey,
+                uploadId,
+                totalPartCount,
+                page,
+                size
+        );
 
-                Series series = null;
-                Contents contents = null;
+        List<MultipartUploadPartUrlResponse> dataList = partUrlPage.getDataList().stream()
+                .map(part -> new MultipartUploadPartUrlResponse(part.partNumber(), part.uploadUrl()))
+                .toList();
 
-                if ( request.mediaType().equals(MediaType.SERIES) ) {
-                        series = seriesRepository.findById(request.originId())
-                                .orElseThrow(() -> new BusinessException(ErrorCode.SERIES_NOT_FOUND));
-                } else if ( request.mediaType().equals(MediaType.CONTENTS) ){
-                        contents = resolveContents(request.originId());
-                } else {
-                        throw new BusinessException(ErrorCode.INVALID_SHORTFORM_TARGET);
-                }
+        return PageResponse.toPageResponse(partUrlPage.getPageInfo(), dataList);
+    }
 
+    @Transactional
+    public ShortFormUpdateResponse updateShortFormUpload(Long shortformId, ShortFormUpdateRequest request, Authentication authentication) {
+        ShortForm shortForm = shortFormRepository.findWithMediaAndUploaderByShortFormId(shortformId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
 
-                media.updateMetadata(request.title(), request.description(), request.publicStatus());
-                // 숏폼 수정 API에서는 영상(원본 URL, 길이, 용량)을 변경하지 않습니다.
-                shortForm.updateMetadata(series, contents);
-
-                Long shortFormId = shortForm.getId();
-                UploadHelper.ImageUpdateUploadResult imageUpdateUploadResult = uploadHelper.prepareImageUpdate(
-                                "short-forms",
-                                shortFormId,
-                                request.posterFileName(),
-                                null,
-                                media.getPosterUrl(),
-                                media.getThumbnailUrl()
-                );
-
-                media.updateImageKeys(
-                                imageUpdateUploadResult.nextPosterUrl(),
-                                imageUpdateUploadResult.nextThumbnailUrl()
-                );
-
-                Long originMediaId = resolveOriginMediaId(series, contents);
-                mediaTagRepository.deleteAllByMedia_Id(media.getId());
-                inheritOriginMediaTags(media, originMediaId);
-
-                return backOfficeShortFormMapper.toShortFormUpdateResponse(
-                                shortFormId,
-                                imageUpdateUploadResult.posterObjectKey(),
-                                imageUpdateUploadResult.thumbnailObjectKey(),
-                                imageUpdateUploadResult.posterUploadUrl(),
-                                imageUpdateUploadResult.thumbnailUploadUrl());
+        Media media = shortForm.getMedia();
+        Long memberId = (Long) authentication.getPrincipal();
+        boolean isEditor = authentication.getAuthorities().stream()
+                .anyMatch(authority -> Role.EDITOR.getKey().equals(authority.getAuthority()));
+        if (isEditor && !media.getUploader().getId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
-        private Contents resolveContents(Long contentsId) {
-                if (contentsId == null) {
-                        return null;
-                }
-                Contents contents = contentsRepository.findById(contentsId)
-                                .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
-                // 시리즈에 속한 콘텐츠는 숏폼 원본으로 허용하지 않습니다.
-                if (contents.getSeries() != null) {
-                        throw new BusinessException(ErrorCode.INVALID_SHORTFORM_CONTENTS_TARGET);
-                }
-                return contents;
+        Series series = null;
+        Contents contents = null;
+
+        if (request.mediaType().equals(MediaType.SERIES)) {
+            series = seriesRepository.findById(request.originId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.SERIES_NOT_FOUND));
+        } else if (request.mediaType().equals(MediaType.CONTENTS)) {
+            contents = resolveContents(request.originId());
+        } else {
+            throw new BusinessException(ErrorCode.INVALID_SHORTFORM_TARGET);
         }
 
-        private Long resolveOriginMediaId(Series series, Contents contents) {
-                if (series != null) {
-                        return series.getMedia().getId();
-                }
-                if (contents != null) {
-                        return contents.getMedia().getId();
-                }
-                throw new BusinessException(ErrorCode.SHORTFORM_ORIGIN_MEDIA_NOT_FOUND);
+        media.updateMetadata(request.title(), request.description(), request.publicStatus());
+        shortForm.updateMetadata(series, contents);
+
+        Long shortFormId = shortForm.getId();
+        UploadHelper.ImageUpdateUploadResult imageUpdateUploadResult = uploadHelper.prepareImageUpdate(
+                "short-forms",
+                shortFormId,
+                request.posterFileName(),
+                null,
+                media.getPosterUrl(),
+                media.getThumbnailUrl()
+        );
+
+        media.updateImageKeys(
+                imageUpdateUploadResult.nextPosterUrl(),
+                imageUpdateUploadResult.nextThumbnailUrl()
+        );
+
+        Long originMediaId = resolveOriginMediaId(series, contents);
+        mediaTagRepository.deleteAllByMedia_Id(media.getId());
+        inheritOriginMediaTags(media, originMediaId);
+
+        return backOfficeShortFormMapper.toShortFormUpdateResponse(
+                shortFormId,
+                imageUpdateUploadResult.posterObjectKey(),
+                imageUpdateUploadResult.thumbnailObjectKey(),
+                imageUpdateUploadResult.posterUploadUrl(),
+                imageUpdateUploadResult.thumbnailUploadUrl());
+    }
+
+    private Contents resolveContents(Long contentsId) {
+        if (contentsId == null) {
+            return null;
+        }
+        Contents contents = contentsRepository.findById(contentsId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
+        if (contents.getSeries() != null) {
+            throw new BusinessException(ErrorCode.INVALID_SHORTFORM_CONTENTS_TARGET);
+        }
+        return contents;
+    }
+
+    private Long resolveOriginMediaId(Series series, Contents contents) {
+        if (series != null) {
+            return series.getMedia().getId();
+        }
+        if (contents != null) {
+            return contents.getMedia().getId();
+        }
+        throw new BusinessException(ErrorCode.SHORTFORM_ORIGIN_MEDIA_NOT_FOUND);
+    }
+
+    private void inheritOriginMediaTags(Media targetMedia, Long originMediaId) {
+        List<MediaTag> originMediaTagList = mediaTagRepository.findWithTagAndCategoryByMediaId(originMediaId);
+        if (originMediaTagList.isEmpty()) {
+            return;
         }
 
-        private void inheritOriginMediaTags(Media targetMedia, Long originMediaId) {
-                List<MediaTag> originMediaTagList = mediaTagRepository.findWithTagAndCategoryByMediaId(originMediaId);
-                if (originMediaTagList.isEmpty()) {
-                        return;
-                }
-
-                List<MediaTag> targetMediaTagList = originMediaTagList.stream()
-                                .map(originMediaTag -> MediaTag.builder()
-                                                .media(targetMedia)
-                                                .tag(originMediaTag.getTag())
-                                                .build())
-                                .toList();
-                mediaTagRepository.saveAll(targetMediaTagList);
-        }
+        List<MediaTag> targetMediaTagList = originMediaTagList.stream()
+                .map(originMediaTag -> MediaTag.builder()
+                        .media(targetMedia)
+                        .tag(originMediaTag.getTag())
+                        .build())
+                .toList();
+        mediaTagRepository.saveAll(targetMediaTagList);
+    }
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/service/BackOfficeShortFormService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/service/BackOfficeShortFormService.java
@@ -7,6 +7,7 @@ import com.ott.api_admin.shortform.dto.response.ShortFormDetailResponse;
 import com.ott.api_admin.shortform.dto.response.ShortFormListResponse;
 import com.ott.api_admin.shortform.dto.response.ShortFormUpdateResponse;
 import com.ott.api_admin.shortform.dto.response.ShortFormUploadResponse;
+import com.ott.api_admin.upload.dto.response.MultipartUploadPartUrlResponse;
 import com.ott.api_admin.shortform.mapper.BackOfficeShortFormMapper;
 import com.ott.api_admin.upload.support.UploadHelper;
 import com.ott.common.web.exception.BusinessException;
@@ -34,6 +35,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -125,7 +127,7 @@ public class BackOfficeShortFormService {
         @Transactional(readOnly = true)
         public ShortFormDetailResponse getShortFormDetail(Long mediaId, Authentication authentication) {
                 ShortForm shortForm = shortFormRepository.findWithMediaAndUploaderByMediaId(mediaId)
-                                .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
+                                .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
 
                 Long memberId = (Long) authentication.getPrincipal();
                 boolean isEditor = authentication.getAuthorities().stream()
@@ -155,8 +157,15 @@ public class BackOfficeShortFormService {
 
                 List<MediaTag> mediaTagList = mediaTagRepository.findWithTagAndCategoryByMediaId(mediaId);
 
-                return backOfficeShortFormMapper.toShortFormDetailResponse(shortForm, media, uploaderNickname,
-                                originMediaTitle, originId, originType, mediaTagList);
+                return backOfficeShortFormMapper.toShortFormDetailResponse(
+                                shortForm,
+                                media,
+                                uploaderNickname,
+                                originMediaTitle,
+                                originId,
+                                originType,
+                                mediaTagList
+                );
         }
 
         @Transactional
@@ -200,7 +209,12 @@ public class BackOfficeShortFormService {
 
                 Long shortFormId = shortForm.getId();
                 UploadHelper.MediaCreateUploadResult mediaCreateUploadResult = uploadHelper.prepareMediaCreate(
-                                "short-forms", shortFormId, request.posterFileName(), null, request.originFileName()
+                                "short-forms",
+                                shortFormId,
+                                request.posterFileName(),
+                                null,
+                                request.originFileName(),
+                                request.videoSize()
                 );
 
                 media.updateImageKeys(
@@ -221,13 +235,85 @@ public class BackOfficeShortFormService {
                                 mediaCreateUploadResult.masterPlaylistObjectKey(),
                                 mediaCreateUploadResult.posterUploadUrl(),
                                 mediaCreateUploadResult.thumbnailUploadUrl(),
-                                mediaCreateUploadResult.originUploadUrl());
+                                mediaCreateUploadResult.originUploadId(),
+                                mediaCreateUploadResult.originTotalPartCount(),
+                                mediaCreateUploadResult.originPartSizeBytes());
+        }
+
+        @Transactional(readOnly = true)
+        public void completeShortFormOriginUpload(
+                        Long shortFormId,
+                        String objectKey,
+                        String uploadId,
+                        List<UploadHelper.MultipartPartETag> parts,
+                        Authentication authentication
+        ) {
+                ShortForm shortForm = shortFormRepository.findWithMediaAndUploaderByShortFormId(shortFormId)
+                                .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
+
+                Media media = shortForm.getMedia();
+                Long memberId = (Long) authentication.getPrincipal();
+                boolean isEditor = authentication.getAuthorities().stream()
+                                .anyMatch(authority -> Role.EDITOR.getKey().equals(authority.getAuthority()));
+                if (isEditor && !media.getUploader().getId().equals(memberId)) {
+                        throw new BusinessException(ErrorCode.FORBIDDEN);
+                }
+
+                uploadHelper.checkObjectKeyMatchesOriginUrl(
+                                objectKey,
+                                shortForm.getOriginUrl(),
+                                ErrorCode.SHORTFORM_ORIGIN_OBJECT_KEY_MISMATCH
+                );
+
+                uploadHelper.completeMultipartUpload(objectKey, uploadId, parts);
+        }
+
+        @Transactional(readOnly = true)
+        public PageResponse<MultipartUploadPartUrlResponse> getShortFormOriginUploadPartUrls(
+                        Long shortFormId,
+                        String objectKey,
+                        String uploadId,
+                        Integer page,
+                        Integer size,
+                        Authentication authentication
+        ) {
+                ShortForm shortForm = shortFormRepository.findWithMediaAndUploaderByShortFormId(shortFormId)
+                                .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
+
+                Media media = shortForm.getMedia();
+                Long memberId = (Long) authentication.getPrincipal();
+                boolean isEditor = authentication.getAuthorities().stream()
+                                .anyMatch(authority -> Role.EDITOR.getKey().equals(authority.getAuthority()));
+                if (isEditor && !media.getUploader().getId().equals(memberId)) {
+                        throw new BusinessException(ErrorCode.FORBIDDEN);
+                }
+
+                uploadHelper.checkObjectKeyMatchesOriginUrl(
+                                objectKey,
+                                shortForm.getOriginUrl(),
+                                ErrorCode.SHORTFORM_ORIGIN_OBJECT_KEY_MISMATCH
+                );
+
+                int totalPartCount = uploadHelper.calculateMultipartPartCount(shortForm.getVideoSize());
+                PageResponse<UploadHelper.MultipartUploadPartUrl> partUrlPage = uploadHelper.getMultipartUploadPartUrlsPage(
+                                objectKey,
+                                uploadId,
+                                totalPartCount,
+                                page,
+                                size
+                );
+
+                List<MultipartUploadPartUrlResponse> dataList = partUrlPage.getDataList().stream()
+                                .map(part -> new MultipartUploadPartUrlResponse(part.partNumber(), part.uploadUrl()))
+                                .toList();
+
+                return PageResponse.toPageResponse(partUrlPage.getPageInfo(), dataList);
         }
 
         @Transactional
         public ShortFormUpdateResponse updateShortFormUpload(Long shortformId, ShortFormUpdateRequest request, Authentication authentication) {
                 ShortForm shortForm = shortFormRepository.findWithMediaAndUploaderByShortFormId(shortformId)
-                                .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
+                                .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
 
                 Media media = shortForm.getMedia();
                 Long memberId = (Long) authentication.getPrincipal();

--- a/apps/api-admin/src/main/java/com/ott/api_admin/upload/dto/request/MultipartUploadCompleteRequest.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/upload/dto/request/MultipartUploadCompleteRequest.java
@@ -1,0 +1,36 @@
+package com.ott.api_admin.upload.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.util.List;
+
+@Schema(description = "멀티파트 업로드 완료 요청")
+public record MultipartUploadCompleteRequest(
+        @Schema(type = "String", description = "S3 object key", example = "contents/10/origin/origin.mp4")
+        @NotBlank
+        String objectKey,
+
+        @Schema(type = "String", description = "S3 멀티파트 upload ID")
+        @NotBlank
+        String uploadId,
+
+        @Schema(description = "업로드된 파트 eTag 목록")
+        @NotEmpty
+        List<@Valid @NotNull PartETagRequest> parts
+) {
+    public record PartETagRequest(
+            @Schema(type = "Integer", description = "파트 번호", example = "1")
+            @Positive
+            int partNumber,
+
+            @Schema(type = "String", description = "파트 eTag")
+            @NotBlank
+            String eTag
+    ) {
+    }
+}

--- a/apps/api-admin/src/main/java/com/ott/api_admin/upload/dto/response/MultipartUploadPartUrlResponse.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/upload/dto/response/MultipartUploadPartUrlResponse.java
@@ -1,0 +1,13 @@
+package com.ott.api_admin.upload.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "멀티파트 파트 업로드 presigned URL 응답")
+public record MultipartUploadPartUrlResponse(
+        @Schema(type = "Integer", description = "파트 번호", example = "1")
+        int partNumber,
+
+        @Schema(type = "String", description = "해당 파트 업로드용 presigned URL")
+        String uploadUrl
+) {
+}

--- a/apps/api-admin/src/main/java/com/ott/api_admin/upload/support/UploadHelper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/upload/support/UploadHelper.java
@@ -257,9 +257,15 @@ public class UploadHelper {
     public void completeMultipartUpload(
             String objectKey,
             String uploadId,
+            int totalPartCount,
             List<MultipartPartETag> partETags
     ) {
-        if (!StringUtils.hasText(objectKey) || !StringUtils.hasText(uploadId) || partETags == null || partETags.isEmpty()) {
+        // 1) 입력값 기본 유효성 검증
+        if (!StringUtils.hasText(objectKey)
+                || !StringUtils.hasText(uploadId)
+                || totalPartCount <= 0
+                || partETags == null
+                || partETags.isEmpty()) {
             throw new BusinessException(ErrorCode.ETAG_LIST_INVALID);
         }
 
@@ -267,10 +273,18 @@ public class UploadHelper {
                 .sorted(Comparator.comparingInt(MultipartPartETag::partNumber))
                 .toList();
 
-        //ETAG List 유효성 검증
+        // 2) 전달된 ETag 개수가 기대 파트 개수와 일치하는지 검증
+        if (normalizedParts.size() != totalPartCount) {
+            throw new BusinessException(ErrorCode.ETAG_LIST_INVALID);
+        }
+
+        // 3) 각 파트의 번호 범위(1..totalPartCount), ETag 값, 중복 여부를 한 번에 검증
         Set<Integer> seenPartNumbers = new HashSet<>();
         normalizedParts.forEach(part -> {
-            if (part.partNumber() <= 0 || !StringUtils.hasText(part.eTag()) || !seenPartNumbers.add(part.partNumber())) {
+            if (part.partNumber() < 1
+                    || part.partNumber() > totalPartCount
+                    || !StringUtils.hasText(part.eTag())
+                    || !seenPartNumbers.add(part.partNumber())) {
                 throw new BusinessException(ErrorCode.ETAG_LIST_INVALID);
             }
         });

--- a/apps/api-admin/src/main/java/com/ott/api_admin/upload/support/UploadHelper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/upload/support/UploadHelper.java
@@ -2,19 +2,41 @@ package com.ott.api_admin.upload.support;
 
 import com.ott.common.web.exception.BusinessException;
 import com.ott.common.web.exception.ErrorCode;
+import com.ott.common.web.response.PageInfo;
+import com.ott.common.web.response.PageResponse;
 import com.ott.domain.member.domain.Member;
 import com.ott.domain.member.repository.MemberRepository;
 import com.ott.infra.s3.service.S3PresignService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
 
 @RequiredArgsConstructor
 @Component
 public class UploadHelper {
 
+    // 5mb s3에서 정한 각 파트 최소 크기( 마지막 파트 제외 )
+    private static final long MIN_MULTIPART_PART_SIZE_BYTES = 5L * 1024L * 1024L;
+    // 5gb s3에서 정한 각 파트 최대 크기
+    private static final long MAX_MULTIPART_PART_SIZE_BYTES = 5L * 1024L * 1024L * 1024L;
+
     private final MemberRepository memberRepository;
     private final S3PresignService s3PresignService;
+
+    // 파트의 기본 크기
+    @Value("${aws.s3.multipart-default-part-size-bytes:16777216}")
+    private long multipartDefaultPartSizeBytes;
+
+    // 최대 파트 갯수
+    @Value("${aws.s3.multipart-max-parts:2000}")
+    private int multipartMaxParts;
 
     public String buildObjectKey(String resourceRoot, Long resourceId, String assetType, String fileName) {
         return resourceRoot + "/" + resourceId + "/" + assetType + "/" + fileName;
@@ -100,6 +122,17 @@ public class UploadHelper {
         return s3PresignService.toObjectUrl(objectKey);
     }
 
+    public void checkObjectKeyMatchesOriginUrl(String objectKey, String expectedOriginUrl, ErrorCode mismatchErrorCode) {
+        if (!StringUtils.hasText(objectKey) || !StringUtils.hasText(expectedOriginUrl)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        String requestOriginUrl = toObjectUrl(objectKey);
+        if (!requestOriginUrl.equals(expectedOriginUrl)) {
+            throw new BusinessException(mismatchErrorCode);
+        }
+    }
+
     public ImageCreateUploadResult prepareImageCreate(
             String resourceRoot,
             Long resourceId,
@@ -163,12 +196,19 @@ public class UploadHelper {
             Long resourceId,
             String posterFileName,
             String thumbnailFileName,
-            String originFileName
+            String originFileName,
+            Integer originFileSizeKb
     ) {
         UploadFileResult posterUpload = prepareRequiredUpload(resourceRoot, resourceId, "poster", posterFileName, false);
         UploadFileResult thumbnailUpload =
                 thumbnailFileName == null ? null : prepareRequiredUpload(resourceRoot, resourceId, "thumbnail", thumbnailFileName, false);
-        UploadFileResult originUpload = prepareRequiredUpload(resourceRoot, resourceId, "origin", originFileName, true);
+        MultipartUploadFileResult originUpload = prepareRequiredMultipartVideoUpload(
+                resourceRoot,
+                resourceId,
+                "origin",
+                originFileName,
+                originFileSizeKb
+        );
 
         String masterPlaylistObjectKey = buildMasterPlaylistObjectKey(resourceRoot, resourceId);
         String masterPlaylistObjectUrl = toObjectUrl(masterPlaylistObjectKey);
@@ -184,14 +224,187 @@ public class UploadHelper {
                 masterPlaylistObjectUrl,
                 posterUpload.uploadUrl(),
                 thumbnailUpload == null ? null : thumbnailUpload.uploadUrl(),
-                originUpload.uploadUrl()
+                originUpload.uploadId(),
+                originUpload.totalPartCount(),
+                originUpload.partSizeBytes()
         );
+    }
+
+    public PageResponse<MultipartUploadPartUrl> getMultipartUploadPartUrlsPage(
+            String objectKey,
+            String uploadId,
+            int totalPartCount,
+            int page,
+            int size
+    ) {
+        if (!StringUtils.hasText(objectKey) || !StringUtils.hasText(uploadId) || totalPartCount <= 0 || page < 0 || size <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        int totalPage = (totalPartCount + size - 1) / size;
+        if (page >= totalPage) {
+            return PageResponse.toPageResponse(PageInfo.toPageInfo(page, totalPage, size), List.of());
+        }
+
+        int startPartNumber = (page * size) + 1;
+        int endPartNumber = Math.min(startPartNumber + size - 1, totalPartCount);
+
+        // 페이징(start - end)범위의 url 생성
+        List<MultipartUploadPartUrl> dataList = buildMultipartPartUploadUrls(objectKey, uploadId, startPartNumber, endPartNumber);
+
+        return PageResponse.toPageResponse(
+                PageInfo.toPageInfo(page, totalPage, size),
+                dataList
+        );
+    }
+
+    public void completeMultipartUpload(
+            String objectKey,
+            String uploadId,
+            List<MultipartPartETag> partETags
+    ) {
+        if (!StringUtils.hasText(objectKey) || !StringUtils.hasText(uploadId) || partETags == null || partETags.isEmpty()) {
+            throw new BusinessException(ErrorCode.ETAG_LIST_INVALID);
+        }
+
+        List<MultipartPartETag> normalizedParts = partETags.stream()
+                .sorted(Comparator.comparingInt(MultipartPartETag::partNumber))
+                .toList();
+
+        Set<Integer> seenPartNumbers = new HashSet<>();
+        normalizedParts.forEach(part -> {
+            if (part.partNumber() <= 0 || !StringUtils.hasText(part.eTag()) || !seenPartNumbers.add(part.partNumber())) {
+                throw new BusinessException(ErrorCode.ETAG_LIST_INVALID);
+            }
+        });
+
+        s3PresignService.completeMultipartUpload(
+                objectKey,
+                uploadId,
+                normalizedParts.stream()
+                        .map(part -> new S3PresignService.MultipartPartETag(part.partNumber(), part.eTag()))
+                        .toList()
+        );
+    }
+
+    public int calculateMultipartPartCount(Integer fileSizeKb) {
+        return calculateMultipartUploadPlan(fileSizeKb).totalPartCount();
+    }
+
+    /**
+     * 5mb, (파일크기/2000), 고정크기(16mb) 중 가장 큰것 선정
+     * <p>
+     * 5mb : s3에서 정한 최소치<br><br>
+     * (파일크기/2000) : 파일이 너무커서 16mb로 2000번 전송해도 부족<br>->파트 갯수 2000개로 한 파트 크기 계산<br><br>
+     * 고정 크기 : 적당한 용량의 파일 -> 파트 크기 16mb로 고정(파트 갯수가 줄어듬)
+     * </p>
+     */
+    public MultipartUploadPlan calculateMultipartUploadPlan(Integer fileSizeKb) {
+        if (multipartDefaultPartSizeBytes <= 0 || multipartMaxParts <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (fileSizeKb == null || fileSizeKb <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        long fileSizeBytes = fileSizeKb.longValue() * 1024L;
+
+        //파일을 2000개로 분할 시 한 파트의 크기
+        long minPartSizeByMaxParts = ceilDiv(fileSizeBytes, multipartMaxParts);
+
+
+        long partSizeBytes = Math.max(
+                MIN_MULTIPART_PART_SIZE_BYTES,
+                Math.max(minPartSizeByMaxParts, multipartDefaultPartSizeBytes)
+        );
+
+        // 파일 크기/2000 이 5기가 넘음 -> s3멀티파트 업로드 불가
+        if (partSizeBytes > MAX_MULTIPART_PART_SIZE_BYTES) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "파일 크기가 너무 큽니다.");
+        }
+
+        // 위에서 정해진 파트 사이즈로 파트 갯수 계산
+        int totalPartCount = (int) ceilDiv(fileSizeBytes, partSizeBytes);
+        if (totalPartCount <= 0 || totalPartCount > multipartMaxParts) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        return new MultipartUploadPlan(totalPartCount, partSizeBytes);
+    }
+
+    private MultipartUploadFileResult prepareRequiredMultipartVideoUpload(
+            String resourceRoot,
+            Long resourceId,
+            String assetType,
+            String fileName,
+            Integer fileSizeKb
+    ) {
+        String sanitizedFileName = sanitizeFileName(fileName);
+        String objectKey = buildObjectKey(resourceRoot, resourceId, assetType, sanitizedFileName);
+        String contentType = resolveVideoContentType(sanitizedFileName);
+        String objectUrl = s3PresignService.toObjectUrl(objectKey);
+
+        MultipartUploadPlan multipartUploadPlan = calculateMultipartUploadPlan(fileSizeKb);
+        String uploadId = s3PresignService.createMultipartUpload(objectKey, contentType);
+
+        return new MultipartUploadFileResult(
+                objectKey,
+                objectUrl,
+                uploadId,
+                multipartUploadPlan.totalPartCount(),
+                multipartUploadPlan.partSizeBytes()
+        );
+    }
+
+    private List<MultipartUploadPartUrl> buildMultipartPartUploadUrls(
+            String objectKey,
+            String uploadId,
+            int startPartNumber,
+            int endPartNumber
+    ) {
+        return IntStream.rangeClosed(startPartNumber, endPartNumber)
+                .mapToObj(partNumber -> new MultipartUploadPartUrl(
+                        partNumber,
+                        s3PresignService.createUploadPartPresignedUrl(objectKey, uploadId, partNumber)
+                ))
+                .toList();
+    }
+
+    private long ceilDiv(long numerator, long denominator) {
+        return (numerator + denominator - 1L) / denominator;
     }
 
     public record UploadFileResult(
             String objectKey,
             String objectUrl,
             String uploadUrl
+    ) {
+    }
+
+    public record MultipartUploadFileResult(
+            String objectKey,
+            String objectUrl,
+            String uploadId,
+            int totalPartCount,
+            long partSizeBytes
+    ) {
+    }
+
+    public record MultipartUploadPlan(
+            int totalPartCount,
+            long partSizeBytes
+    ) {
+    }
+
+    public record MultipartUploadPartUrl(
+            int partNumber,
+            String uploadUrl
+    ) {
+    }
+
+    public record MultipartPartETag(
+            int partNumber,
+            String eTag
     ) {
     }
 
@@ -226,7 +439,9 @@ public class UploadHelper {
             String masterPlaylistObjectUrl,
             String posterUploadUrl,
             String thumbnailUploadUrl,
-            String originUploadUrl
+            String originUploadId,
+            int originTotalPartCount,
+            long originPartSizeBytes
     ) {
     }
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/upload/support/UploadHelper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/upload/support/UploadHelper.java
@@ -58,6 +58,7 @@ public class UploadHelper {
         }
     }
 
+    //업로드할 파일명 정규화
     public String sanitizeFileName(String fileName) {
         String trimmed = fileName.trim();
         int extensionDelimiterIndex = trimmed.lastIndexOf('.');
@@ -84,34 +85,30 @@ public class UploadHelper {
                 .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
     }
 
-    public UploadFileResult prepareRequiredUpload(
+    public UploadFileResult createImageUpload(
             String resourceRoot,
             Long resourceId,
             String assetType,
-            String fileName,
-            boolean isVideo
+            String fileName
     ) {
         String sanitizedFileName = sanitizeFileName(fileName);
         String objectKey = buildObjectKey(resourceRoot, resourceId, assetType, sanitizedFileName);
-        String contentType = isVideo
-                ? resolveVideoContentType(sanitizedFileName)
-                : resolveImageContentType(sanitizedFileName);
+        String contentType = resolveImageContentType(sanitizedFileName);
         String objectUrl = s3PresignService.toObjectUrl(objectKey);
         String uploadUrl = s3PresignService.createPutPresignedUrl(objectKey, contentType);
         return new UploadFileResult(objectKey, objectUrl, uploadUrl);
     }
 
-    public UploadFileResult prepareOptionalUpload(
+    public UploadFileResult createImageUploadOptional(
             String resourceRoot,
             Long resourceId,
             String assetType,
-            String fileName,
-            boolean isVideo
+            String fileName
     ) {
         if (!StringUtils.hasText(fileName)) {
             return null;
         }
-        return prepareRequiredUpload(resourceRoot, resourceId, assetType, fileName, isVideo);
+        return createImageUpload(resourceRoot, resourceId, assetType, fileName);
     }
 
     public String buildMasterPlaylistObjectKey(String resourceRoot, Long resourceId) {
@@ -122,7 +119,7 @@ public class UploadHelper {
         return s3PresignService.toObjectUrl(objectKey);
     }
 
-    public void checkObjectKeyMatchesOriginUrl(String objectKey, String expectedOriginUrl, ErrorCode mismatchErrorCode) {
+    public void validateOriginObjectKey(String objectKey, String expectedOriginUrl, ErrorCode mismatchErrorCode) {
         if (!StringUtils.hasText(objectKey) || !StringUtils.hasText(expectedOriginUrl)) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
@@ -139,8 +136,8 @@ public class UploadHelper {
             String posterFileName,
             String thumbnailFileName
     ) {
-        UploadFileResult posterUpload = prepareRequiredUpload(resourceRoot, resourceId, "poster", posterFileName, false);
-        UploadFileResult thumbnailUpload = prepareRequiredUpload(resourceRoot, resourceId, "thumbnail", thumbnailFileName, false);
+        UploadFileResult posterUpload = createImageUpload(resourceRoot, resourceId, "poster", posterFileName);
+        UploadFileResult thumbnailUpload = createImageUpload(resourceRoot, resourceId, "thumbnail", thumbnailFileName);
 
         return new ImageCreateUploadResult(
                 posterUpload.objectKey(),
@@ -160,8 +157,8 @@ public class UploadHelper {
             String currentPosterUrl,
             String currentThumbnailUrl
     ) {
-        UploadFileResult posterUpload = prepareOptionalUpload(resourceRoot, resourceId, "poster", posterFileName, false);
-        UploadFileResult thumbnailUpload = prepareOptionalUpload(resourceRoot, resourceId, "thumbnail", thumbnailFileName, false);
+        UploadFileResult posterUpload = createImageUploadOptional(resourceRoot, resourceId, "poster", posterFileName);
+        UploadFileResult thumbnailUpload = createImageUploadOptional(resourceRoot, resourceId, "thumbnail", thumbnailFileName);
 
         String finalPosterUrl = currentPosterUrl;
         String finalThumbnailUrl = currentThumbnailUrl;
@@ -199,13 +196,12 @@ public class UploadHelper {
             String originFileName,
             Integer originFileSizeKb
     ) {
-        UploadFileResult posterUpload = prepareRequiredUpload(resourceRoot, resourceId, "poster", posterFileName, false);
+        UploadFileResult posterUpload = createImageUpload(resourceRoot, resourceId, "poster", posterFileName);
         UploadFileResult thumbnailUpload =
-                thumbnailFileName == null ? null : prepareRequiredUpload(resourceRoot, resourceId, "thumbnail", thumbnailFileName, false);
-        MultipartUploadFileResult originUpload = prepareRequiredMultipartVideoUpload(
+                thumbnailFileName == null ? null : createImageUpload(resourceRoot, resourceId, "thumbnail", thumbnailFileName);
+        MultipartUploadFileResult originUpload = createVideoMultipartUpload(
                 resourceRoot,
                 resourceId,
-                "origin",
                 originFileName,
                 originFileSizeKb
         );
@@ -230,7 +226,7 @@ public class UploadHelper {
         );
     }
 
-    public PageResponse<MultipartUploadPartUrl> getMultipartUploadPartUrlsPage(
+    public PageResponse<MultipartUploadPartUrl> getMultipartPartUrls(
             String objectKey,
             String uploadId,
             int totalPartCount,
@@ -271,6 +267,7 @@ public class UploadHelper {
                 .sorted(Comparator.comparingInt(MultipartPartETag::partNumber))
                 .toList();
 
+        //ETAG List 유효성 검증
         Set<Integer> seenPartNumbers = new HashSet<>();
         normalizedParts.forEach(part -> {
             if (part.partNumber() <= 0 || !StringUtils.hasText(part.eTag()) || !seenPartNumbers.add(part.partNumber())) {
@@ -287,8 +284,18 @@ public class UploadHelper {
         );
     }
 
-    public int calculateMultipartPartCount(Integer fileSizeKb) {
-        return calculateMultipartUploadPlan(fileSizeKb).totalPartCount();
+    /**
+     * s3에 생긴 멀티파트 업로드 세션을 제거합니다.
+     */
+    public void abortMultipartUpload(String objectKey, String uploadId) {
+        if (!StringUtils.hasText(objectKey) || !StringUtils.hasText(uploadId)) {
+            return;
+        }
+        s3PresignService.abortMultipartUpload(objectKey, uploadId);
+    }
+
+    public int getMultipartPartCount(Integer fileSizeKb) {
+        return getMultipartPlan(fileSizeKb).totalPartCount();
     }
 
     /**
@@ -299,7 +306,7 @@ public class UploadHelper {
      * 고정 크기 : 적당한 용량의 파일 -> 파트 크기 16mb로 고정(파트 갯수가 줄어듬)
      * </p>
      */
-    public MultipartUploadPlan calculateMultipartUploadPlan(Integer fileSizeKb) {
+    public MultipartUploadPlan getMultipartPlan(Integer fileSizeKb) {
         if (multipartDefaultPartSizeBytes <= 0 || multipartMaxParts <= 0) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
@@ -332,19 +339,18 @@ public class UploadHelper {
         return new MultipartUploadPlan(totalPartCount, partSizeBytes);
     }
 
-    private MultipartUploadFileResult prepareRequiredMultipartVideoUpload(
+    private MultipartUploadFileResult createVideoMultipartUpload(
             String resourceRoot,
             Long resourceId,
-            String assetType,
             String fileName,
             Integer fileSizeKb
     ) {
         String sanitizedFileName = sanitizeFileName(fileName);
-        String objectKey = buildObjectKey(resourceRoot, resourceId, assetType, sanitizedFileName);
+        String objectKey = buildObjectKey(resourceRoot, resourceId, "origin", sanitizedFileName);
         String contentType = resolveVideoContentType(sanitizedFileName);
         String objectUrl = s3PresignService.toObjectUrl(objectKey);
 
-        MultipartUploadPlan multipartUploadPlan = calculateMultipartUploadPlan(fileSizeKb);
+        MultipartUploadPlan multipartUploadPlan = getMultipartPlan(fileSizeKb);
         String uploadId = s3PresignService.createMultipartUpload(objectKey, contentType);
 
         return new MultipartUploadFileResult(

--- a/modules/common-web/src/main/java/com/ott/common/web/exception/ErrorCode.java
+++ b/modules/common-web/src/main/java/com/ott/common/web/exception/ErrorCode.java
@@ -56,7 +56,6 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "B106", "댓글을 찾을 수 없습니다"),
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "B107", "북마크를 찾을 수 없습니다"),
     EPISODE_NOT_REGISTERED(HttpStatus.NOT_FOUND, "B108", "아직 에피소드가 등록되지 않았습니다."),
-  
     SHORT_FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "B109", "숏폼을 찾을 수 없습니다"),
 
    // ========== Business (B) - 비즈니스 (정책/유효성: 200번대) ==========
@@ -66,6 +65,10 @@ public enum ErrorCode {
     INVALID_ROLE_CHANGE(HttpStatus.BAD_REQUEST, "B204", "허용되지 않는 역할 변경입니다"),
     COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "B205", "본인이 작성한 댓글만 수정/삭제할 수 있습니다"),
     INVALID_PLAYLIST_SOURCE(HttpStatus.BAD_REQUEST, "B206", "재생목록 소스(source)는 필수값입니다"),
+
+    CONTENTS_ORIGIN_OBJECT_KEY_MISMATCH(HttpStatus.BAD_REQUEST, "B207", "contents objectKey가 원본 영상 URL과 일치하지 않습니다"),
+    SHORTFORM_ORIGIN_OBJECT_KEY_MISMATCH(HttpStatus.BAD_REQUEST, "B208", "shortform objectKey가 원본 영상 URL과 일치하지 않습니다"),
+    ETAG_LIST_INVALID(HttpStatus.BAD_REQUEST, "B209", "multipart eTag 목록이 유효하지 않습니다"),
 
     // ========== Business (B) - 비즈니스 (미디어/파일 전용: 300번대) ==========
     UNSUPPORTED_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "B301", "지원하지 않는 이미지 확장자입니다"),
@@ -90,3 +93,4 @@ public enum ErrorCode {
     private final String code;
     private final String message;
 }
+

--- a/modules/infra-s3/src/main/java/com/ott/infra/s3/config/S3PresignerConfig.java
+++ b/modules/infra-s3/src/main/java/com/ott/infra/s3/config/S3PresignerConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -14,14 +13,6 @@ public class S3PresignerConfig {
     @Bean
     public S3Presigner s3Presigner(@Value("${aws.region:ap-northeast-2}") String region) {
         return S3Presigner.builder()
-                .region(Region.of(region))
-                .credentialsProvider(DefaultCredentialsProvider.builder().build())
-                .build();
-    }
-
-    @Bean
-    public S3Client s3Client(@Value("${aws.region:ap-northeast-2}") String region) {
-        return S3Client.builder()
                 .region(Region.of(region))
                 .credentialsProvider(DefaultCredentialsProvider.builder().build())
                 .build();

--- a/modules/infra-s3/src/main/java/com/ott/infra/s3/config/S3PresignerConfig.java
+++ b/modules/infra-s3/src/main/java/com/ott/infra/s3/config/S3PresignerConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -14,7 +15,15 @@ public class S3PresignerConfig {
     public S3Presigner s3Presigner(@Value("${aws.region:ap-northeast-2}") String region) {
         return S3Presigner.builder()
                 .region(Region.of(region))
-                .credentialsProvider(DefaultCredentialsProvider.create())
+                .credentialsProvider(DefaultCredentialsProvider.builder().build())
+                .build();
+    }
+
+    @Bean
+    public S3Client s3Client(@Value("${aws.region:ap-northeast-2}") String region) {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.builder().build())
                 .build();
     }
 }

--- a/modules/infra-s3/src/main/java/com/ott/infra/s3/service/S3PresignService.java
+++ b/modules/infra-s3/src/main/java/com/ott/infra/s3/service/S3PresignService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
@@ -132,20 +133,19 @@ public class S3PresignService {
         }
     }
 
-    // TODO: Incomplete multipart uploads are currently cleaned up by S3 Lifecycle TTL policy.
-//    public void abortMultipartUpload(String objectKey, String uploadId) {
-//        try {
-//            s3Client.abortMultipartUpload(
-//                    AbortMultipartUploadRequest.builder()
-//                            .bucket(bucket)
-//                            .key(objectKey)
-//                            .uploadId(uploadId)
-//                            .build()
-//            );
-//        } catch (SdkException ex) {
-//            throw new IllegalStateException("Failed to abort multipart upload.", ex);
-//        }
-//    }
+    public void abortMultipartUpload(String objectKey, String uploadId) {
+        try {
+            s3Client.abortMultipartUpload(
+                    AbortMultipartUploadRequest.builder()
+                            .bucket(bucket)
+                            .key(objectKey)
+                            .uploadId(uploadId)
+                            .build()
+            );
+        } catch (SdkException ex) {
+            throw new IllegalStateException("Failed to abort multipart upload.", ex);
+        }
+    }
 
     public String toObjectUrl(String objectKey) {
         String encodedKey = URLEncoder.encode(objectKey, StandardCharsets.UTF_8)

--- a/modules/infra-s3/src/main/java/com/ott/infra/s3/service/S3PresignService.java
+++ b/modules/infra-s3/src/main/java/com/ott/infra/s3/service/S3PresignService.java
@@ -3,19 +3,30 @@ package com.ott.infra.s3.service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedUploadPartRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.UploadPartPresignRequest;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.List;
 
 @Service
 public class S3PresignService {
 
     private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
     private final String region;
     private final String bucket;
     private final String publicBaseUrl;
@@ -23,11 +34,14 @@ public class S3PresignService {
 
     public S3PresignService(
             S3Presigner s3Presigner,
+            S3Client s3Client,
             @Value("${aws.region:ap-northeast-2}") String region,
             @Value("${aws.s3.bucket:local-bucket}") String bucket,
             @Value("${aws.s3.public-base-url:}") String publicBaseUrl,
-            @Value("${aws.s3.presign-expire-seconds:600}") long expireSeconds) {
+            @Value("${aws.s3.presign-expire-seconds:600}") long expireSeconds
+    ) {
         this.s3Presigner = s3Presigner;
+        this.s3Client = s3Client;
         this.region = region;
         this.bucket = bucket;
         this.publicBaseUrl = publicBaseUrl;
@@ -50,23 +64,104 @@ public class S3PresignService {
             PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
             return presignedRequest.url().toString();
         } catch (SdkException ex) {
-            throw new IllegalStateException("업로드 URL 생성에 실패했습니다.", ex);
+            throw new IllegalStateException("Failed to create upload URL.", ex);
         }
     }
 
-    // objectKey를 실제 S3 객체 URL 형식으로 변환합니다.
-    // - 한글/공백/특수문자 깨짐 방지를 위해 URL 인코딩
-    // - 공백은 '+' 대신 '%20'으로 정규화
-    // - 경로 구분자는 유지하기 위해 '%2F'를 '/'로 복원
+    public String createMultipartUpload(String objectKey, String contentType) {
+        try {
+            CreateMultipartUploadResponse response = s3Client.createMultipartUpload(
+                    CreateMultipartUploadRequest.builder()
+                            .bucket(bucket)
+                            .key(objectKey)
+                            .contentType(contentType)
+                            .build()
+            );
+            return response.uploadId();
+        } catch (SdkException ex) {
+            throw new IllegalStateException("Failed to initialize multipart upload.", ex);
+        }
+    }
+
+    // Generates a presigned URL locally via SDK signing logic.
+    // No outbound request to S3 is made at this step.
+    public String createUploadPartPresignedUrl(String objectKey, String uploadId, int partNumber) {
+        try {
+            UploadPartRequest uploadPartRequest = UploadPartRequest.builder()
+                    .bucket(bucket)
+                    .key(objectKey)
+                    .uploadId(uploadId)
+                    .partNumber(partNumber)
+                    .build();
+
+            UploadPartPresignRequest presignRequest = UploadPartPresignRequest.builder()
+                    .signatureDuration(Duration.ofSeconds(expireSeconds))
+                    .uploadPartRequest(uploadPartRequest)
+                    .build();
+
+            PresignedUploadPartRequest presignedRequest = s3Presigner.presignUploadPart(presignRequest);
+            return presignedRequest.url().toString();
+        } catch (SdkException ex) {
+            throw new IllegalStateException("Failed to create multipart upload part URL.", ex);
+        }
+    }
+
+    public void completeMultipartUpload(String objectKey, String uploadId, List< MultipartPartETag> partETags) {
+        try {
+            List<CompletedPart> completedParts = partETags.stream()
+                    .map(part -> CompletedPart.builder()
+                            .partNumber(part.partNumber())
+                            .eTag(part.eTag())
+                            .build())
+                    .toList();
+
+            CompletedMultipartUpload completedMultipartUpload = CompletedMultipartUpload.builder()
+                    .parts(completedParts)
+                    .build();
+
+            s3Client.completeMultipartUpload(
+                    CompleteMultipartUploadRequest.builder()
+                            .bucket(bucket)
+                            .key(objectKey)
+                            .uploadId(uploadId)
+                            .multipartUpload(completedMultipartUpload)
+                            .build()
+            );
+        } catch (SdkException ex) {
+            throw new IllegalStateException("Failed to complete multipart upload.", ex);
+        }
+    }
+
+    // TODO: Incomplete multipart uploads are currently cleaned up by S3 Lifecycle TTL policy.
+//    public void abortMultipartUpload(String objectKey, String uploadId) {
+//        try {
+//            s3Client.abortMultipartUpload(
+//                    AbortMultipartUploadRequest.builder()
+//                            .bucket(bucket)
+//                            .key(objectKey)
+//                            .uploadId(uploadId)
+//                            .build()
+//            );
+//        } catch (SdkException ex) {
+//            throw new IllegalStateException("Failed to abort multipart upload.", ex);
+//        }
+//    }
+
     public String toObjectUrl(String objectKey) {
         String encodedKey = URLEncoder.encode(objectKey, StandardCharsets.UTF_8)
                 .replace("+", "%20")
                 .replace("%2F", "/");
 
-        // public-base-url이 설정되어 있으면 우선 사용하고, 없으면 기존 S3 URL 규칙으로 fallback합니다.
+        // Use public-base-url when configured; otherwise fall back to the default S3 URL format.
         String baseUrl = (publicBaseUrl == null || publicBaseUrl.isBlank())
                 ? "https://" + bucket + ".s3." + region + ".amazonaws.com"
                 : publicBaseUrl.replaceAll("/+$", "");
         return baseUrl + "/" + encodedKey;
+    }
+
+    public record MultipartPartETag(
+            int partNumber,
+            String eTag
+    ) {
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 멀티 파트 업로드 구현

### 📷 스크린샷
[메타 업로드]
<img width="1082" height="920" alt="image" src="https://github.com/user-attachments/assets/2671fd8d-541c-4eb4-9b5a-38085c6a0e9a" />

[멀티파트 url 생성]
<img width="1082" height="912" alt="image" src="https://github.com/user-attachments/assets/95b86a86-b22f-41ee-9a3e-9876894bc575" />

[파트 업로드]
<img width="1084" height="874" alt="image" src="https://github.com/user-attachments/assets/f76a3f77-3f31-4574-95da-b425d2baff4d" />

[파트 업로드 완료 요청]
<img width="1068" height="939" alt="image" src="https://github.com/user-attachments/assets/20da0c68-5271-4fd3-af56-928540ae846b" />


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호
close #164 

## 💬 리뷰 요구사항
> 업로드 파일의 용량 제한을 최소화 하기 위해 
기본 파트용량 16mb, 
s3 최소 용량 5mb, 
큰 파일은 2000개 분할 시 1개의 용량

 3개중에 가장 큰 용량을 선택하는 로직이 있습니다. 코드에 최대한 주석 붙여 놓았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 콘텐츠·숏폼 대상 멀티파트 업로드 지원 추가
  * 파트별 presigned URL 조회 API 및 업로드 완료 API 추가
  * 멀티파트 관련 요청/응답 DTO 및 페이징 응답 추가

* **개선사항**
  * 업로드 응답에 업로드 ID·전체 파트 수·파트 크기 포함
  * S3 멀티파트 흐름(생성/완료/중단) 및 파트 페이징 강화
  * 업로드 준비 흐름과 로깅·오류 처리 개선

* **버그 수정**
  * 객체 키 검증 강화 및 ETag 목록 검증 추가
  * 업로드 요청의 필수 필드(null) 검증 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->