### PR TITLE
[FEAT]: 백오피스 사용자 목록 조회 시 status ACTIVE 추가

### DIFF
--- a/modules/domain/src/main/java/com/ott/domain/member/repository/MemberRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/member/repository/MemberRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.ott.domain.member.repository;
 
+import com.ott.domain.common.Status;
 import com.ott.domain.member.domain.Member;
 import com.ott.domain.member.domain.Role;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -25,6 +26,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         List<Member> memberList = queryFactory
                 .selectFrom(member)
                 .where(
+                        member.status.eq(Status.ACTIVE),
                         nicknameContains(searchWord),
                         roleEq(role)
                 )
@@ -37,6 +39,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .select(member.count())
                 .from(member)
                 .where(
+                        member.status.eq(Status.ACTIVE),
                         nicknameContains(searchWord),
                         roleEq(role)
                 );


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 백오피스 사용자 목록 조회 시 status ACTIVE 추가


### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #174 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

Soft Delete로 인해 백오피스 사용자 관리 목록 조회 시 ACTIVE만 조회하도록 변경했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 회원 조회 시 활성 상태의 회원만 표시되도록 개선되었습니다. 이제 시스템에서는 활성화된 회원 정보만 필터링하여 조회합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->