### PR TITLE
[OT-339][FIX]: 썸네일, 포스터 프론트와 통합

### DIFF
--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/dto/response/ContentsListResponse.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/dto/response/ContentsListResponse.java
@@ -12,7 +12,7 @@ public record ContentsListResponse(
 
                 @Schema(type = "Long", description = "미디어 ID", example = "1") Long mediaId,
 
-                @Schema(type = "String", description = "포스터(세로, 5:7) URL", example = "https://cdn.example.com/thumbnail.jpg") String posterUrl,
+                @Schema(type = "String", description = "썸네일 URL", example = "https://cdn.example.com/thumbnail.jpg") String thumbnailUrl,
 
                 @Schema(type = "String", description = "콘텐츠 제목", example = "기생충") String title,
 

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/mapper/BackOfficeContentsMapper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/mapper/BackOfficeContentsMapper.java
@@ -17,7 +17,7 @@ public class BackOfficeContentsMapper {
     public ContentsListResponse toContentsListResponse(Media media) {
         return new ContentsListResponse(
                 media.getId(),
-                media.getPosterUrl(),
+                media.getThumbnailUrl(),
                 media.getTitle(),
                 media.getPublicStatus(),
                 media.getCreatedDate().toLocalDate()

--- a/apps/api-user/src/main/java/com/ott/api_user/bookmark/dto/response/BookmarkShortFormResponse.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/bookmark/dto/response/BookmarkShortFormResponse.java
@@ -19,15 +19,15 @@ public class BookmarkShortFormResponse {
     @Schema(type ="String", description = "미디어 설명", example = "오늘은 북마크 API를 작성했다. 참 재미있었다!")
     private String description;
 
-    @Schema(type ="String", description = "썸네일 URL", example = "https://cdn.ott.com/thumbnails/1.jpg")
-    private String thumbnailUrl;
+    @Schema(type ="String", description = "포스터 URL", example = "https://cdn.ott.com/posters/1.jpg")
+    private String posterUrl;
 
     public static BookmarkShortFormResponse from(Bookmark bookmark) {
         return BookmarkShortFormResponse.builder()
                 .mediaId(bookmark.getMedia().getId())
                 .title(bookmark.getMedia().getTitle())
                 .description(bookmark.getMedia().getDescription())
-                .thumbnailUrl(bookmark.getMedia().getThumbnailUrl())
+                .posterUrl(bookmark.getMedia().getPosterUrl())
                 .build();
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 마이페이지에서 숏츠 조회 시 포스터 내려오도록 변경
- [x] 관리자페이지에서 콘텐츠 조회 시 썸네일 내려오도록 변경

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
close #184 


## 💬 리뷰 요구사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * API 응답의 이미지 URL 필드를 일관성 있게 정규화했습니다. 콘텐츠 목록 및 북마크 조회에서 올바른 이미지 소스를 사용하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->