### PR TITLE
[OT-332] [FIX]: 백오피스 시리즈인 콘텐츠 상세 조회 시 시리즈 북마크 수 노출

### DIFF
--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/mapper/BackOfficeContentsMapper.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/mapper/BackOfficeContentsMapper.java
@@ -24,7 +24,7 @@ public class BackOfficeContentsMapper {
         );
     }
 
-    public ContentsDetailResponse toContentsDetailResponse(Long seriesId, Contents contents, Media media, String uploaderNickname, String seriesTitle, List<MediaTag> mediaTagList) {
+    public ContentsDetailResponse toContentsDetailResponse(Long seriesId, Contents contents, Media media, String uploaderNickname, String seriesTitle, List<MediaTag> mediaTagList, Long bookmarkCount) {
         String categoryName = extractCategoryName(mediaTagList);
         List<String> tagNameList = extractTagNameList(mediaTagList);
 
@@ -43,7 +43,7 @@ public class BackOfficeContentsMapper {
                 categoryName,
                 tagNameList,
                 media.getPublicStatus(),
-                media.getBookmarkCount(),
+                bookmarkCount,
                 media.getCreatedDate().toLocalDate()
         );
     }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsReader.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsReader.java
@@ -66,6 +66,7 @@ public class BackOfficeContentsReader {
 
         Media media = contents.getMedia();
         String uploaderNickname = media.getUploader().getNickname();
+        Long bookmarkCount = media.getBookmarkCount();
 
         Long originMediaId = mediaId;
         String seriesTitle = null;
@@ -75,11 +76,12 @@ public class BackOfficeContentsReader {
             originMediaId = originMedia.getId();
             seriesTitle = originMedia.getTitle();
             seriesId = contents.getSeries().getId();
+            bookmarkCount = originMedia.getBookmarkCount();
         }
 
         List<MediaTag> mediaTagList = mediaTagRepository.findWithTagAndCategoryByMediaId(originMediaId);
 
-        return backOfficeContentsMapper.toContentsDetailResponse(seriesId, contents, media, uploaderNickname, seriesTitle, mediaTagList);
+        return backOfficeContentsMapper.toContentsDetailResponse(seriesId, contents, media, uploaderNickname, seriesTitle, mediaTagList, bookmarkCount);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 백오피스 시리즈인 콘텐츠 상세 조회 시 시리즈 북마크 수 노출


### 📷 스크린샷

<img width="750" height="887" alt="image" src="https://github.com/user-attachments/assets/d1dba880-4915-4c2e-a900-ed69637d3b52" />


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #182 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

시리즈인 콘텐츠이더라도 북마크 수가 콘텐츠의 북마크 수로 표시되는 현상을 시리즈의 북마크 수로 표시되도록 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 콘텐츠 세부 정보 응답에서 북마크 수 정보가 정확하게 전달되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->