### PR TITLE
[OT-341][FIX]:배포 환경 watch_history upsert 저장 에러 수정

### DIFF
--- a/apps/api-user/src/main/java/com/ott/api_user/history/service/WatchHistoryService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/history/service/WatchHistoryService.java
@@ -20,10 +20,12 @@ import com.ott.domain.watch_history.repository.WatchHistoryRepository;
 
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 
 
 @Service
+@Slf4j
 @Transactional
 @RequiredArgsConstructor
 public class WatchHistoryService {
@@ -36,8 +38,11 @@ public class WatchHistoryService {
         Contents contents = contentsRepository.findByMediaIdAndStatusAndMedia_PublicStatus(mediaId, Status.ACTIVE, PublicStatus.PUBLIC)
                 .orElseThrow(()-> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
         
-                
+
+        
         watchHistoryRepository.upsertWatchHistory(memberId, contents.getId());
+
+        log.info("이벤트 발송 직전");
         
         eventPublisher.publishEvent(new WatchHistoryCreatedEvent(memberId));
 

--- a/modules/domain/src/main/java/com/ott/domain/watch_history/repository/WatchHistoryRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/watch_history/repository/WatchHistoryRepository.java
@@ -18,21 +18,38 @@ public interface WatchHistoryRepository extends JpaRepository<WatchHistory, Long
     void softDeleteAllByMemberId(@Param("memberId") Long memberId);
 
 
+    // @Modifying
+    // @Query(value = """
+    //         INSERT INTO watch_history (member_id, contents_id, last_watched_at, re_watch_count, created_date, modified_date, status)
+    //         VALUES (:memberId, :contentsId, NOW(), 0, NOW(), NOW(), 'ACTIVE')
+    //         ON DUPLICATE KEY UPDATE
+    //             last_watched_at = NOW(),
+    //             re_watch_count = re_watch_count + 1,
+    //             modified_date = NOW(),
+    //             status = 'ACTIVE'
+    //         """, nativeQuery = true)
+    // void upsertWatchHistory(
+    //         @Param("memberId") Long memberId,
+    //         @Param("contentsId") Long contentsId
+    // );
+    
     @Modifying
     @Query(value = """
-            INSERT INTO watch_history (member_id, contents_id, last_watched_at, re_watch_count, created_date, modified_date, status)
-            VALUES (:memberId, :contentsId, NOW(), 0, NOW(), NOW(), 'ACTIVE')
+            INSERT INTO watch_history (
+                member_id, contents_id, last_watched_at, re_watch_count, 
+                created_date, modified_date, status, is_used_for_ml
+            )
+            VALUES (:memberId, :contentsId, NOW(), 0, NOW(), NOW(), 'ACTIVE', false)
             ON DUPLICATE KEY UPDATE
-                last_watched_at = NOW(),
+                last_watched_at = VALUES(last_watched_at),
                 re_watch_count = re_watch_count + 1,
-                modified_date = NOW(),
+                modified_date = VALUES(modified_date),
                 status = 'ACTIVE'
             """, nativeQuery = true)
     void upsertWatchHistory(
-            @Param("memberId") Long memberId,
-            @Param("contentsId") Long contentsId
+        @Param("memberId") Long memberId,
+        @Param("contentsId") Long contentsId
     );
-    
     // Optional<WatchHistory> findByMember_IdAndContents_IdAndStatus(Long memberId, Long contentsId , Status status);
 
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 배포 환경 watch_history upsert 저장 에러 수정
-  직접 SQL을 써서 저장할 때, AI 분석용 정보가 빠져 있어서 저장 에러가 났던 문제 수정

원인:
INSERT INTO watch_history (member_id, contents_id, ...) (is_used_for_ml은 없음)  
→ DB  에는 Defalut false 라고 명시되어 있으니 처음 시청 시에는 0 으로 채워줌.

이때, 우리는 테스트를 위해 직접 db 에 접속해서 데이터를 지움.
→ db  내부의 인덱스가 메모리에는 아직 데이터가 남아있음.  (물리적 제거 전)

→ 이때 찰나에 서버는 또 다시 upsert 쿼리로 새로운 이력을 저장하는데, DB  엔진은 이를 INSERT가 아닌 UPDATE 상황으로 간주할지, 혹은 완전히 새로운 INSERT로 볼지 결정하는 과정에서 충돌이 발생함.

따라서 SQL 문에 필수 컬럼   is_used_for_ml  = false 로 명시해줘서 SQL 엔진의 원자성 확보함,. (유령 데이터 방지)



### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [ ] 테스트는 잘 통과했나요?
- [ ] 충돌을 해결했나요?
- [ ] 이슈는 등록했나요?
- [ ] 라벨은 등록했나요?
그

## #️⃣ 연관된 이슈
> ex) #186 
closes #186 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 애플리케이션 성능 모니터링을 위한 로깅 기능 개선으로 시스템 안정성 강화

* **Refactor**
  * 감시 기록 저장소의 데이터 처리 메커니즘을 최적화하여 데이터 일관성과 시스템 성능 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->