### PR TITLE
[OT-341][FIX]: 환기 카드에 사용된 미디어 재시청 시 is_used_for_ml = 0 으로 업서트 처리

### DIFF
--- a/apps/api-user/src/test/java/com/ott/api_user/playlist/service/PlaylistServiceTest.java
+++ b/apps/api-user/src/test/java/com/ott/api_user/playlist/service/PlaylistServiceTest.java
@@ -1,0 +1,133 @@
+package com.ott.api_user.playlist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ott.api_user.playlist.dto.response.TagPlaylistResponse;
+import com.ott.common.web.exception.BusinessException;
+import com.ott.common.web.exception.ErrorCode;
+import com.ott.domain.category.domain.Category;
+import com.ott.domain.common.MediaType;
+import com.ott.domain.member.domain.Member;
+import com.ott.domain.member.domain.Provider;
+import com.ott.domain.member.domain.Role;
+import com.ott.domain.media.repository.MediaRepository;
+import com.ott.domain.media.repository.TagContentProjection;
+import com.ott.domain.tag.domain.Tag;
+import com.ott.domain.tag.repository.TagRepository;
+import com.ott.domain.watch_history.repository.RecentWatchProjection;
+import com.ott.domain.watch_history.repository.WatchHistoryRepository;
+import com.ott.domain.contents.repository.ContentsRepository;
+import com.ott.domain.member.repository.MemberRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class PlaylistServiceTest {
+
+    @Mock
+    private ContentsRepository contentsRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @Mock
+    private MediaRepository mediaRepository;
+
+    @Mock
+    private WatchHistoryRepository watchHistoryRepository;
+
+    @InjectMocks
+    private PlaylistService playlistService;
+
+    @Test
+    void getRecommendContentsByTag_returnsMappedResponses() {
+        Long memberId = 1L;
+        Long tagId = 2L;
+
+        Member member = Member.builder()
+                .id(memberId)
+                .email("tester@ott.com")
+                .nickname("tester")
+                .role(Role.MEMBER)
+                .provider(Provider.KAKAO)
+                .build();
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        Category tagCategory = Category.builder().id(1L).name("default").build();
+        Tag tag = Tag.builder().id(tagId).category(tagCategory).name("tag").build();
+        when(tagRepository.findById(tagId)).thenReturn(Optional.of(tag));
+
+        TagContentProjection projection = new TagContentProjection(10L, "poster-url", MediaType.CONTENTS);
+        when(mediaRepository.findRecommendContentsByTagId(tagId, 20))
+                .thenReturn(List.of(projection));
+
+        List<TagPlaylistResponse> result = playlistService.getRecommendContentsByTag(memberId, tagId);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getMediaId()).isEqualTo(10L);
+        assertThat(result.get(0).getPosterUrl()).isEqualTo("poster-url");
+        assertThat(result.get(0).getMediaType()).isEqualTo(MediaType.CONTENTS);
+    }
+
+    @Test
+    void getRecommendContentsByTag_throwsWhenMemberMissing() {
+        Long memberId = 5L;
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> playlistService.getRecommendContentsByTag(memberId, 99L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+        verify(tagRepository, never()).findById(any());
+    }
+
+    @Test
+    void getWatchHistoryPlaylist_returnsPageResponse() {
+        Long memberId = 3L;
+        int page = 2;
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(
+                Member.builder()
+                        .id(memberId)
+                        .email("watcher@ott.com")
+                        .nickname("watcher")
+                        .role(Role.MEMBER)
+                        .provider(Provider.KAKAO)
+                        .build()));
+
+        Pageable pageable = PageRequest.of(page, 10);
+        List<RecentWatchProjection> projections = List.of(
+                new RecentWatchProjection(11L, MediaType.SERIES, "first-poster", 30, 600),
+                new RecentWatchProjection(12L, MediaType.CONTENTS, "second-poster", 0, 360)
+        );
+        Page<RecentWatchProjection> watchHistoryPage = new PageImpl<>(projections, pageable, 5);
+
+        when(watchHistoryRepository.findWatchHistoryByMemberId(memberId, pageable)).thenReturn(watchHistoryPage);
+
+        var response = playlistService.getWatchHistoryPlaylist(memberId, page);
+
+        assertThat(response.getPageInfo().getCurrentPage()).isEqualTo(page);
+        assertThat(response.getPageInfo().getTotalPage()).isEqualTo(1);
+        assertThat(response.getDataList()).hasSize(2);
+        assertThat(response.getDataList().get(0).getMediaId()).isEqualTo(11L);
+        assertThat(response.getDataList().get(1).getDuration()).isEqualTo(360);
+    }
+}

--- a/modules/domain/src/main/java/com/ott/domain/watch_history/repository/WatchHistoryRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/watch_history/repository/WatchHistoryRepository.java
@@ -44,7 +44,8 @@ public interface WatchHistoryRepository extends JpaRepository<WatchHistory, Long
                 last_watched_at = VALUES(last_watched_at),
                 re_watch_count = re_watch_count + 1,
                 modified_date = VALUES(modified_date),
-                status = 'ACTIVE'
+                status = 'ACTIVE',
+                is_used_for_ml = 0;
             """, nativeQuery = true)
     void upsertWatchHistory(
         @Param("memberId") Long memberId,


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x]  기존 코드에서 이미 환기 카드에 사용된 미디어를 시청해도 시청이력만 upsert 가 되고 환기 카드 필터링에 사용되는 is_used_for_ml 필드가 여전히 1로 되어있었음, →따라서 해당 컨텐츠를 재시청하면 환기 카드가 발생하지 못했었음.
<img width="858" height="374" alt="image" src="https://github.com/user-attachments/assets/137848f9-b1fa-4fe5-bb5f-b7599fcd19f1" />

- [x] 따라서 쿼리 작성에 upsert 시에는 is_used_for_ml  = 0 으로 명시해줘야함.

```
@Modifying
    @Query(value = """
            INSERT INTO watch_history (
                member_id, contents_id, last_watched_at, re_watch_count, 
                created_date, modified_date, status, is_used_for_ml
            )
            VALUES (:memberId, :contentsId, NOW(), 0, NOW(), NOW(), 'ACTIVE', false)
            ON DUPLICATE KEY UPDATE
                last_watched_at = VALUES(last_watched_at),
                re_watch_count = re_watch_count + 1,
                modified_date = VALUES(modified_date),
                status = 'ACTIVE',
                is_used_for_ml = 0;
            """, nativeQuery = true)
    void upsertWatchHistory(
        @Param("memberId") Long memberId,
        @Param("contentsId") Long contentsId
    );
```


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [ ] 테스트는 잘 통과했나요?
- [ ] 충돌을 해결했나요?
- [ ] 이슈는 등록했나요?
- [ ] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요
