### PR TITLE
[OT-335] [FEAT]: 트랜스코딩 이벤트 아웃박스 추가

### DIFF
--- a/apps/api-admin/build.gradle
+++ b/apps/api-admin/build.gradle
@@ -15,8 +15,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// ShedLock
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.10.0'
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/ApiAdminApplication.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/ApiAdminApplication.java
@@ -7,10 +7,11 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
-
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @SpringBootApplication
+@EnableScheduling
 @ComponentScan(basePackages = "com.ott")
 @EntityScan(basePackages = "com.ott.domain")
 @EnableJpaRepositories(basePackages = "com.ott.domain")

--- a/apps/api-admin/src/main/java/com/ott/api_admin/config/shedlock/ShedLockConfig.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/config/shedlock/ShedLockConfig.java
@@ -14,10 +14,10 @@ import javax.sql.DataSource;
 public class ShedLockConfig {
 
     @Bean
-    public LockProvider lockProvider(DataSource dataSource) {
+    public LockProvider lockProvider(JdbcTemplate jdbcTemplate) {
         return new JdbcTemplateLockProvider(
             JdbcTemplateLockProvider.Configuration.builder()
-                .withJdbcTemplate(new JdbcTemplate(dataSource))
+                    .withJdbcTemplate(jdbcTemplate)
                 .usingDbTime() // DB 시간을 기준으로 락 시간 계산
                 .build()
         );

--- a/apps/api-admin/src/main/java/com/ott/api_admin/config/shedlock/ShedLockConfig.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/config/shedlock/ShedLockConfig.java
@@ -7,8 +7,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-import javax.sql.DataSource;
-
 @Configuration
 @EnableSchedulerLock(defaultLockAtMostFor = "10m")
 public class ShedLockConfig {

--- a/apps/api-admin/src/main/java/com/ott/api_admin/config/shedlock/ShedLockConfig.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/config/shedlock/ShedLockConfig.java
@@ -1,0 +1,25 @@
+package com.ott.api_admin.config.shedlock;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+            JdbcTemplateLockProvider.Configuration.builder()
+                .withJdbcTemplate(new JdbcTemplate(dataSource))
+                .usingDbTime() // DB 시간을 기준으로 락 시간 계산
+                .build()
+        );
+    }
+}

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
@@ -12,7 +12,6 @@ import com.ott.api_admin.upload.dto.response.MultipartUploadPartUrlResponse;
 import com.ott.api_admin.upload.support.UploadHelper;
 import com.ott.common.web.response.PageResponse;
 import com.ott.domain.common.PublicStatus;
-import com.ott.infra.mq.TranscodeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
@@ -74,17 +74,7 @@ public class BackOfficeContentsService {
         // Phase 3: IngestJob 생성 (쓰기 트랜잭션)
         IngestJobResult result = writer.createIngestJobWithOutbox(contentsId, objectKey);
 
-        // Phase 4: 메시지 발행 (트랜잭션 밖)
-        transcodePublisher.publish(new TranscodeMessage(
-                result.mediaId(),
-                result.ingestJobId(),
-                result.originObjectKey(), 
-                result.fileSize(),
-                result.mediaType()
-                )
-        );
-
-        log.info("업로드 완료 + 트랜스코딩 요청 - contentsId: {}, mediaId: {}, ingestJobId: {}",
+        log.info("outbox 저장 완료 - contentsId: {}, mediaId: {}, ingestJobId: {}",
                 contentsId, result.mediaId(), result.ingestJobId());
     }
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsService.java
@@ -62,8 +62,8 @@ public class BackOfficeContentsService {
     // ── complete ──
 
     public void completeContentsOriginUpload(
-            Long contentsId, String objectKey, String uploadId,
-            List<UploadHelper.MultipartPartETag> parts) {
+            Long contentsId, String objectKey, String uploadId, List<UploadHelper.MultipartPartETag> parts
+    ) {
 
         // Phase 1: 검증 + 정보 조회 (readOnly 트랜잭션)
         int totalPartCount = reader.getContentsUploadInfo(contentsId, objectKey);
@@ -72,7 +72,7 @@ public class BackOfficeContentsService {
         uploadHelper.completeMultipartUpload(objectKey, uploadId, totalPartCount, parts);
 
         // Phase 3: IngestJob 생성 (쓰기 트랜잭션)
-        IngestJobResult result = writer.createIngestJob(contentsId, objectKey);
+        IngestJobResult result = writer.createIngestJobWithOutbox(contentsId, objectKey);
 
         // Phase 4: 메시지 발행 (트랜잭션 밖)
         transcodePublisher.publish(new TranscodeMessage(

--- a/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsWriter.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/content/service/BackOfficeContentsWriter.java
@@ -22,6 +22,8 @@ import com.ott.domain.media.domain.MediaStatus;
 import com.ott.domain.media.repository.MediaRepository;
 import com.ott.domain.media_tag.repository.MediaTagRepository;
 import com.ott.domain.member.domain.Member;
+import com.ott.domain.outbox.domain.TranscodeOutbox;
+import com.ott.domain.outbox.repository.TranscodeOutboxRepository;
 import com.ott.domain.series.domain.Series;
 import com.ott.domain.series.repository.SeriesRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,13 +38,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class BackOfficeContentsWriter {
 
     private final BackOfficeContentsMapper backOfficeContentsMapper;
+
     private final MediaRepository mediaRepository;
     private final MediaTagRepository mediaTagRepository;
     private final ContentsRepository contentsRepository;
     private final SeriesRepository seriesRepository;
     private final IngestJobRepository ingestJobRepository;
+    private final TranscodeOutboxRepository transcodeOutboxRepository;
+
     private final UploadHelper uploadHelper;
     private final MediaTagLinker mediaTagLinker;
+
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
@@ -134,7 +140,7 @@ public class BackOfficeContentsWriter {
     }
 
     @Transactional
-    public IngestJobResult createIngestJob(Long contentsId, String originObjectKey) {
+    public IngestJobResult createIngestJobWithOutbox(Long contentsId, String originObjectKey) {
         Contents contents = contentsRepository.findById(contentsId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CONTENTS_NOT_FOUND));
         Media media = contents.getMedia();
@@ -143,20 +149,29 @@ public class BackOfficeContentsWriter {
             throw new BusinessException(ErrorCode.ALREADY_INGESTED);
         }
 
+        // 1. IngestJob 저장
         IngestJob ingestJob = ingestJobRepository.save(
                 IngestJob.builder()
                         .media(media)
                         .ingestStatus(IngestStatus.PENDING)
                         .build());
 
-        log.info("IngestJob 생성 - contentsId: {}, mediaId: {}, ingestJobId: {}",
-                contentsId, media.getId(), ingestJob.getId());
+        // 2. Outbox 저장
+        TranscodeOutbox outbox = TranscodeOutbox.builder()
+                .mediaId(media.getId())
+                .ingestJobId(ingestJob.getId())
+                .originUrl(originObjectKey)
+                .fileSize((long) contents.getVideoSize() * 1024)
+                .mediaType(MediaType.CONTENTS)
+                .build();
+        transcodeOutboxRepository.save(outbox);
+
+        log.info("IngestJob + Outbox 생성 - contentsId: {}, mediaId: {}, ingestJobId: {}, outboxId: {}",
+                contentsId, media.getId(), ingestJob.getId(), outbox.getId());
 
         return new IngestJobResult(
-                media.getId(),
-                ingestJob.getId(),
-                originObjectKey,
-                (long) contents.getVideoSize() * 1024,
+                media.getId(), ingestJob.getId(),
+                originObjectKey, (long) contents.getVideoSize() * 1024,
                 MediaType.CONTENTS);
     }
 

--- a/apps/api-admin/src/main/java/com/ott/api_admin/outbox/poller/OutboxPoller.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/outbox/poller/OutboxPoller.java
@@ -57,8 +57,8 @@ public class OutboxPoller {
             } catch (Exception e) {
                 outboxWriter.markAsFailed(transcodeOutbox.getId(), e.getMessage());
 
-                log.warn("Outbox 발행 실패 - outboxId: {}, retryCount: {}/{}, error: {}",
-                        transcodeOutbox.getId(), transcodeOutbox.getRetryCount(), transcodeOutbox.getMaxRetries(), e.getMessage());
+                log.warn("Outbox 발행 실패 - outboxId: {}, error: {}",
+                        transcodeOutbox.getId(), e.getMessage());
             }
         }
     }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/outbox/poller/OutboxPoller.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/outbox/poller/OutboxPoller.java
@@ -1,0 +1,68 @@
+package com.ott.api_admin.outbox.poller;
+
+import com.ott.api_admin.outbox.writer.OutboxWriter;
+import com.ott.api_admin.publish.RabbitTranscodePublisher;
+import com.ott.domain.outbox.domain.OutboxStatus;
+import com.ott.domain.outbox.domain.TranscodeOutbox;
+import com.ott.domain.outbox.repository.TranscodeOutboxRepository;
+import com.ott.infra.mq.TranscodeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxPoller {
+
+    private final TranscodeOutboxRepository outboxRepository;
+    private final RabbitTranscodePublisher rabbitTranscodePublisher;
+    private final OutboxWriter outboxWriter;
+
+    /**
+     * 10초마다 PENDING 상태의 Outbox 메시지를 폴링하여 발행한다.
+     *
+     * - 발행 성공 → PUBLISHED
+     * - 발행 실패 → retryCount++ (maxRetries 초과 시 FAILED)
+     */
+    @Scheduled(fixedDelay = 10000)
+    public void pollAndPublish() {
+        List<TranscodeOutbox> pendingList =
+                outboxRepository.findTop50ByOutboxStatusOrderByCreatedDateAsc(OutboxStatus.PENDING);
+
+        if (pendingList.isEmpty()) {
+            return;
+        }
+
+        log.info("Outbox 폴링 - {}건 발행 시도", pendingList.size());
+
+        for (TranscodeOutbox transcodeOutbox : pendingList) {
+            try {
+                rabbitTranscodePublisher.publish(toMessage(transcodeOutbox));
+                outboxWriter.markAsPublished(transcodeOutbox.getId());
+
+                log.info("Outbox 발행 성공 - outboxId: {}, ingestJobId: {}",
+                        transcodeOutbox.getId(), transcodeOutbox.getIngestJobId());
+
+            } catch (Exception e) {
+                outboxWriter.markAsFailed(transcodeOutbox.getId(), e.getMessage());
+
+                log.warn("Outbox 발행 실패 - outboxId: {}, retryCount: {}/{}, error: {}",
+                        transcodeOutbox.getId(), transcodeOutbox.getRetryCount(), transcodeOutbox.getMaxRetries(), e.getMessage());
+            }
+        }
+    }
+
+    private TranscodeMessage toMessage(TranscodeOutbox transcodeOutbox) {
+        return new TranscodeMessage(
+                transcodeOutbox.getMediaId(),
+                transcodeOutbox.getIngestJobId(),
+                transcodeOutbox.getOriginUrl(),
+                transcodeOutbox.getFileSize(),
+                transcodeOutbox.getMediaType()
+        );
+    }
+}

--- a/apps/api-admin/src/main/java/com/ott/api_admin/outbox/poller/OutboxPoller.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/outbox/poller/OutboxPoller.java
@@ -8,6 +8,7 @@ import com.ott.domain.outbox.repository.TranscodeOutboxRepository;
 import com.ott.infra.mq.TranscodeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -24,11 +25,17 @@ public class OutboxPoller {
 
     /**
      * 10초마다 PENDING 상태의 Outbox 메시지를 폴링하여 발행한다.
+     * ShedLock을 사용하여 다중 서버 환경에서 단 한 대만 실행되도록 보장한다.
      *
      * - 발행 성공 → PUBLISHED
      * - 발행 실패 → retryCount++ (maxRetries 초과 시 FAILED)
      */
     @Scheduled(fixedDelay = 10000)
+    @SchedulerLock(
+            name = "OutboxPoller_pollAndPublish",
+            lockAtMostFor = "5m",
+            lockAtLeastFor = "5s"
+    )
     public void pollAndPublish() {
         List<TranscodeOutbox> pendingList =
                 outboxRepository.findTop50ByOutboxStatusOrderByCreatedDateAsc(OutboxStatus.PENDING);

--- a/apps/api-admin/src/main/java/com/ott/api_admin/outbox/writer/OutboxWriter.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/outbox/writer/OutboxWriter.java
@@ -1,0 +1,28 @@
+package com.ott.api_admin.outbox.writer;
+
+import com.ott.domain.outbox.domain.TranscodeOutbox;
+import com.ott.domain.outbox.repository.TranscodeOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxWriter {
+
+    private final TranscodeOutboxRepository outboxRepository;
+
+    @Transactional
+    public void markAsPublished(Long id) {
+        outboxRepository.findById(id)
+                .ifPresent(TranscodeOutbox::markPublished);
+    }
+
+    @Transactional
+    public void markAsFailed(Long id, String errorMessage) {
+        outboxRepository.findById(id)
+                .ifPresent(outbox -> outbox.markFailed(errorMessage));
+    }
+}

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/service/BackOfficeShortFormService.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/service/BackOfficeShortFormService.java
@@ -72,7 +72,8 @@ public class BackOfficeShortFormService {
 
     public void completeShortFormOriginUpload(
             Long shortFormId, String objectKey, String uploadId,
-            List<UploadHelper.MultipartPartETag> parts, Authentication authentication) {
+            List<UploadHelper.MultipartPartETag> parts, Authentication authentication
+    ) {
 
         // Phase 1: 검증 + 권한 체크 + 정보 조회 (readOnly 트랜잭션)
         int totalPartCount = reader.getShortFormUploadInfo(shortFormId, objectKey, authentication);
@@ -80,20 +81,10 @@ public class BackOfficeShortFormService {
         // Phase 2: S3 멀티파트 완료 (트랜잭션 밖 — 외부 호출)
         uploadHelper.completeMultipartUpload(objectKey, uploadId, totalPartCount, parts);
 
-        // Phase 3: IngestJob 생성 (쓰기 트랜잭션)
-        IngestJobResult result = writer.createIngestJob(shortFormId, objectKey);
+        // Phase 3: IngestJob + Outbox 생성 (쓰기 트랜잭션)
+        IngestJobResult result = writer.createIngestJobWithOutbox(shortFormId, objectKey);
 
-        // Phase 4: 메시지 발행 (트랜잭션 밖)
-        transcodePublisher.publish(new TranscodeMessage(
-                result.mediaId(),
-                result.ingestJobId(),
-                result.originObjectKey(),
-                result.fileSize(),
-                result.mediaType()
-                )
-        );
-
-        log.info("업로드 완료 + 트랜스코딩 요청 - shortFormId: {}, mediaId: {}, ingestJobId: {}",
+        log.info("Outbox 저장 완료 - shortFormId: {}, mediaId: {}, ingestJobId: {}",
                 shortFormId, result.mediaId(), result.ingestJobId());
     }
 }

--- a/apps/api-admin/src/main/java/com/ott/api_admin/shortform/service/BackOfficeShortFormWriter.java
+++ b/apps/api-admin/src/main/java/com/ott/api_admin/shortform/service/BackOfficeShortFormWriter.java
@@ -23,6 +23,8 @@ import com.ott.domain.member.domain.Role;
 import com.ott.domain.ingest_job.domain.IngestJob;
 import com.ott.domain.ingest_job.domain.IngestStatus;
 import com.ott.domain.ingest_job.repository.IngestJobRepository;
+import com.ott.domain.outbox.domain.TranscodeOutbox;
+import com.ott.domain.outbox.repository.TranscodeOutboxRepository;
 import com.ott.domain.series.domain.Series;
 import com.ott.domain.series.repository.SeriesRepository;
 import com.ott.domain.short_form.domain.ShortForm;
@@ -47,6 +49,7 @@ public class BackOfficeShortFormWriter {
     private final ContentsRepository contentsRepository;
     private final ShortFormRepository shortFormRepository;
     private final IngestJobRepository ingestJobRepository;
+    private final TranscodeOutboxRepository transcodeOutboxRepository;
     private final UploadHelper uploadHelper;
 
     @Transactional
@@ -196,7 +199,7 @@ public class BackOfficeShortFormWriter {
     }
 
     @Transactional
-    public IngestJobResult createIngestJob(Long shortFormId, String originObjectKey) {
+    public IngestJobResult createIngestJobWithOutbox(Long shortFormId, String originObjectKey) {
         ShortForm shortForm = shortFormRepository.findById(shortFormId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
         Media media = shortForm.getMedia();
@@ -205,14 +208,25 @@ public class BackOfficeShortFormWriter {
             throw new BusinessException(ErrorCode.ALREADY_INGESTED);
         }
 
+        // 1. IngestJob 저장
         IngestJob ingestJob = ingestJobRepository.save(
                 IngestJob.builder()
                         .media(media)
                         .ingestStatus(IngestStatus.PENDING)
                         .build());
 
-        log.info("IngestJob 생성 - shortFormId: {}, mediaId: {}, ingestJobId: {}",
-                shortFormId, media.getId(), ingestJob.getId());
+        // 2. Outbox 저장
+        TranscodeOutbox outbox = TranscodeOutbox.builder()
+                .mediaId(media.getId())
+                .ingestJobId(ingestJob.getId())
+                .originUrl(originObjectKey)
+                .fileSize((long) shortForm.getVideoSize() * 1024)
+                .mediaType(MediaType.SHORT_FORM)
+                .build();
+        transcodeOutboxRepository.save(outbox);
+
+        log.info("IngestJob + Outbox 생성 - shortFormId: {}, mediaId: {}, ingestJobId: {}, outboxId: {}",
+                shortFormId, media.getId(), ingestJob.getId(), outbox.getId());
 
         return new IngestJobResult(
                 media.getId(),

--- a/modules/domain/src/main/java/com/ott/domain/outbox/domain/OutboxStatus.java
+++ b/modules/domain/src/main/java/com/ott/domain/outbox/domain/OutboxStatus.java
@@ -1,0 +1,15 @@
+package com.ott.domain.outbox.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OutboxStatus {
+    PENDING("PENDING", "PENDING"),
+    PUBLISHED("PUBLISHED", "PUBLISHED"),
+    FAILED("FAILED", "FAILED");
+
+    private final String key;
+    private final String value;
+}

--- a/modules/domain/src/main/java/com/ott/domain/outbox/domain/TranscodeOutbox.java
+++ b/modules/domain/src/main/java/com/ott/domain/outbox/domain/TranscodeOutbox.java
@@ -9,7 +9,13 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Getter
-@Table(name = "transcode_outbox")
+@Table(
+    name = "transcode_outbox",
+    indexes = {
+        @Index(name = "idx_outbox_status_created_date",
+                columnList = "outbox_status, created_date")
+    }
+)
 public class TranscodeOutbox extends BaseEntity {
 
     @Id

--- a/modules/domain/src/main/java/com/ott/domain/outbox/domain/TranscodeOutbox.java
+++ b/modules/domain/src/main/java/com/ott/domain/outbox/domain/TranscodeOutbox.java
@@ -1,0 +1,71 @@
+package com.ott.domain.outbox.domain;
+
+import com.ott.domain.common.BaseEntity;
+import com.ott.domain.common.MediaType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Getter
+@Table(name = "transcode_outbox")
+public class TranscodeOutbox extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "media_id", nullable = false)
+    private Long mediaId;
+
+    @Column(name = "ingest_job_id", nullable = false)
+    private Long ingestJobId;
+
+    @Column(name = "origin_url", nullable = false, length = 500)
+    private String originUrl;
+
+    @Column(name = "file_size")
+    private Long fileSize;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "media_type", nullable = false)
+    private MediaType mediaType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "outbox_status", nullable = false)
+    private OutboxStatus outboxStatus;
+
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount;
+
+    @Column(name = "max_retries", nullable = false)
+    private int maxRetries;
+
+    @Column(name = "error_message", length = 500)
+    private String errorMessage;
+
+    @Builder
+    public TranscodeOutbox(Long mediaId, Long ingestJobId, String originUrl, Long fileSize, MediaType mediaType, int maxRetries) {
+        this.mediaId = mediaId;
+        this.ingestJobId = ingestJobId;
+        this.originUrl = originUrl;
+        this.fileSize = fileSize;
+        this.mediaType = mediaType;
+        this.outboxStatus = OutboxStatus.PENDING;
+        this.retryCount = 0;
+        this.maxRetries = (maxRetries > 0) ? maxRetries : 5;
+    }
+
+    public void markPublished() {
+        this.outboxStatus = OutboxStatus.PUBLISHED;
+    }
+
+    public void markFailed(String errorMessage) {
+        this.retryCount++;
+        this.errorMessage = errorMessage;
+        if (this.retryCount >= this.maxRetries) {
+            this.outboxStatus = OutboxStatus.FAILED;
+        }
+    }
+}

--- a/modules/domain/src/main/java/com/ott/domain/outbox/repository/TranscodeOutboxRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/outbox/repository/TranscodeOutboxRepository.java
@@ -1,0 +1,15 @@
+package com.ott.domain.outbox.repository;
+
+import com.ott.domain.outbox.domain.OutboxStatus;
+import com.ott.domain.outbox.domain.TranscodeOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TranscodeOutboxRepository extends JpaRepository<TranscodeOutbox, Long> {
+
+    // 발행 대기 중인 Outbox 메시지를 생성순으로 조회 (배치 크기 제한)
+    List<TranscodeOutbox> findTop50ByOutboxStatusOrderByCreatedDateAsc(OutboxStatus status);
+}

--- a/modules/infra-db/src/main/resources/db/migration/V12__transcode_outbox.sql
+++ b/modules/infra-db/src/main/resources/db/migration/V12__transcode_outbox.sql
@@ -24,7 +24,20 @@ CREATE TABLE IF NOT EXISTS transcode_outbox
     CONSTRAINT pk_transcode_outbox PRIMARY KEY (id)
 ) engine = InnoDB;
 
+CREATE TABLE IF NOT EXISTS shedlock
+(
+    name       VARCHAR(64)  NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at  TIMESTAMP(3) NOT NULL,
+    locked_by  VARCHAR(255) NOT NULL,
+    CONSTRAINT pk_shedlock PRIMARY KEY (name)
+);
+
+
 ALTER TABLE transcode_outbox
     ADD CONSTRAINT fk_transcode_outbox_to_ingest_job
         FOREIGN KEY (ingest_job_id)
             REFERENCES ingest_job (id);
+
+CREATE INDEX idx_outbox_status_created_date
+    ON transcode_outbox (outbox_status, created_date);

--- a/modules/infra-db/src/main/resources/db/migration/V12__transcode_outbox.sql
+++ b/modules/infra-db/src/main/resources/db/migration/V12__transcode_outbox.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS transcode_outbox
+(
+    id            BIGINT AUTO_INCREMENT PRIMARY KEY       NOT NULL,
+
+    -- 메시지 페이로드
+    media_id      BIGINT                                  NOT NULL,
+    ingest_job_id BIGINT                                  NOT NULL,
+    origin_url    VARCHAR(500)                            NOT NULL,
+    file_size     BIGINT                                  NULL,
+    media_type    ENUM ('CONTENTS', 'SHORT_FORM')         NOT NULL,
+
+    -- Outbox 상태
+    outbox_status ENUM ('PENDING', 'PUBLISHED', 'FAILED') NOT NULL,
+    retry_count   INT                                     NOT NULL,
+    max_retries   INT                                     NOT NULL,
+
+    -- 추적 정보
+    error_message VARCHAR(500)                            NULL,
+
+    created_date  DATETIME                                NOT NULL,
+    modified_date DATETIME                                NOT NULL,
+    status        ENUM ('DELETE','ACTIVE')                NOT NULL,
+
+    CONSTRAINT pk_transcode_outbox PRIMARY KEY (id)
+) engine = InnoDB;
+
+ALTER TABLE transcode_outbox
+    ADD CONSTRAINT fk_transcode_outbox_to_ingest_job
+        FOREIGN KEY (ingest_job_id)
+            REFERENCES ingest_job (id);

--- a/modules/infra-db/src/main/resources/db/migration/V12__transcode_outbox.sql
+++ b/modules/infra-db/src/main/resources/db/migration/V12__transcode_outbox.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS transcode_outbox
 (
-    id            BIGINT AUTO_INCREMENT PRIMARY KEY       NOT NULL,
+    id            BIGINT AUTO_INCREMENT                   NOT NULL,
 
     -- 메시지 페이로드
     media_id      BIGINT                                  NOT NULL,


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 트랜스코딩 이벤트 아웃박스 추가
- [x] 다중 서버 ShedLock 추가

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #183 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

### 1. 발행 쪽 유실 방지를 위한 아웃박스 패턴 도입
- 최근 순, PENDING 상태인 것들을 50개씩 뽑습니다.

### 2. 다중 서버 환경 스케줄러 중복 실행 방지
- ShedLock으로 하나만 실행되도록 구성했습니다.
- 노션 트러블슈팅에 다른 방안 써놨습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 분산 잠금 기반 스케줄링이 추가되어 스케줄된 작업의 단일 실행을 보장합니다.
  * 트랜스코드용 아웃박스 엔터티와 폴링/게시 흐름이 도입되어 비동기 전송이 안정화되었습니다.

* **개선사항**
  * 멀티 노드 환경에서 작업 처리 신뢰성과 재시도/상태 관리가 향상되었습니다.
  * 관련 DB 마이그레이션이 추가되어 아웃박스 및 잠금 테이블이 생성됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->