### PR TITLE
[OT-356][FIX]: mediaId를 통한 숏폼 조회 로직 수정

### DIFF
--- a/apps/api-user/src/main/java/com/ott/api_user/shortform/controller/ShortFormController.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/shortform/controller/ShortFormController.java
@@ -44,7 +44,7 @@ public class ShortFormController implements ShortFormApi {
             @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody ShortFormEventRequest request) {
 
-        clickEventService.saveClickEvent(memberId, request.getShortFormId(), ClickType.SHORT_CLICK);
+        clickEventService.saveClickEvent(memberId, request.getMediaId(), ClickType.SHORT_CLICK);
         return ResponseEntity.noContent().build();
     }
 
@@ -54,7 +54,7 @@ public class ShortFormController implements ShortFormApi {
             @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody ShortFormEventRequest request) {
 
-        clickEventService.saveClickEvent(memberId, request.getShortFormId(), ClickType.CTA_CLICK);
+        clickEventService.saveClickEvent(memberId, request.getMediaId(), ClickType.CTA_CLICK);
         return ResponseEntity.noContent().build();
     }
 }

--- a/apps/api-user/src/main/java/com/ott/api_user/shortform/dto/request/ShortFormEventRequest.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/shortform/dto/request/ShortFormEventRequest.java
@@ -12,5 +12,5 @@ public class ShortFormEventRequest {
 
     @NotNull(message = "숏폼 ID 는 필수입니다.")
     @Schema(type = "Long" , description = "이벤트가 발생한 숏폼 ID", example = "5")
-    private Long shortFormId;
+    private Long mediaId;
 }

--- a/apps/api-user/src/main/java/com/ott/api_user/shortform/service/ClickEventService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/shortform/service/ClickEventService.java
@@ -25,11 +25,11 @@ public class ClickEventService {
     private final MemberRepository memberRepository;
     private final ShortFormRepository shortFormRepository;
 
-    public void saveClickEvent(Long memberId, Long shortFormId, ClickType clickType){
+    public void saveClickEvent(Long memberId, Long mediaId, ClickType clickType){
         Member member = memberRepository.findById(memberId)
             .orElseThrow(()-> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        ShortForm shortForm = shortFormRepository.findById(shortFormId)
+        ShortForm shortForm = shortFormRepository.findByMediaId(mediaId)
             .orElseThrow(() -> new BusinessException(ErrorCode.SHORT_FORM_NOT_FOUND));
 
         


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

이전 프론트엔드 측의 요청에 따라, 숏폼 목록 조회 시 응답 기준을 shortFormId에서 mediaId 변경하였는데, 
클라이언트로부터 mediaId를 전달받아 클릭 이벤트를 저장하는 ClickEventService의 기존 로직은 
여전히 shortFormId 기반의 조회(findById)를 수행하고 있어 데이터 불일치 및 조회 오류가 발생했습니다.

해결: mediaId로 숏폼을 정확히 조회하도록 서비스 로직을 수정

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [ ] 테스트는 잘 통과했나요?
- [ ] 충돌을 해결했나요?
- [ ] 이슈는 등록했나요?
- [ ] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) #204 
closes #204 


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- 단편형 콘텐츠의 이벤트 추적 방식이 변경되었습니다. 조회 및 클릭 이벤트 기록 시 단편형 ID 대신 미디어 ID를 사용하도록 업데이트되었습니다. API 요청 매개변수도 함께 변경되었으므로, API 통합 업데이트가 필요합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->