### PR TITLE
[OT-362][FIX]: 미디어 타입에 따른 조회 시 상태 조건 추가

### DIFF
--- a/apps/api-user/src/main/java/com/ott/api_user/playlist/service/PlaylistStrategyService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/playlist/service/PlaylistStrategyService.java
@@ -10,6 +10,7 @@ import com.ott.common.web.exception.ErrorCode;
 import com.ott.common.web.response.PageInfo;
 import com.ott.common.web.response.PageResponse;
 import com.ott.domain.common.MediaType;
+import com.ott.domain.media.domain.MediaStatus;
 import com.ott.domain.common.PublicStatus;
 import com.ott.domain.common.Status;
 import com.ott.domain.contents.domain.Contents;
@@ -191,7 +192,7 @@ public class PlaylistStrategyService {
     private Long getFirstEpisodeMediaId(Long seriesId) {
         Pageable limitOne = PageRequest.of(0, 1);
         Page<Contents> firstContentPage = contentsRepository
-                .findBySeries_Media_IdAndStatusAndMedia_PublicStatusOrderByIdAsc(seriesId, Status.ACTIVE, PublicStatus.PUBLIC, limitOne);
+                .findBySeries_Media_IdAndStatusAndMedia_PublicStatusAndMedia_MediaStatusOrderByIdAsc(seriesId, Status.ACTIVE, PublicStatus.PUBLIC, MediaStatus.COMPLETED, limitOne);
 
         if (firstContentPage.isEmpty()) {
             // 시리즈 껍데기만 있고 콘텐츠가 아직 안 올라온 예외 상황 방어

--- a/apps/api-user/src/main/java/com/ott/api_user/series/service/SeriesService.java
+++ b/apps/api-user/src/main/java/com/ott/api_user/series/service/SeriesService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.ott.domain.media.domain.MediaStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -16,21 +17,17 @@ import com.ott.common.web.exception.BusinessException;
 import com.ott.common.web.exception.ErrorCode;
 import com.ott.common.web.response.PageInfo;
 import com.ott.common.web.response.PageResponse;
-import com.ott.domain.bookmark.domain.Bookmark;
 import com.ott.domain.bookmark.repository.BookmarkRepository;
 import com.ott.domain.category.repository.CategoryRepository;
 import com.ott.domain.common.PublicStatus;
 import com.ott.domain.common.Status;
 import com.ott.domain.contents.domain.Contents;
 import com.ott.domain.contents.repository.ContentsRepository;
-import com.ott.domain.likes.domain.Likes;
 import com.ott.domain.likes.repository.LikesRepository;
-import com.ott.domain.playback.domain.Playback;
 import com.ott.domain.playback.repository.PlaybackRepository;
 import com.ott.domain.series.domain.Series;
 import com.ott.domain.series.repository.SeriesRepository;
 import com.ott.domain.tag.repository.TagRepository;
-import com.ott.domain.watch_history.domain.WatchHistory;
 import com.ott.domain.watch_history.repository.WatchHistoryRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -82,7 +79,7 @@ public class SeriesService {
 
                
                 Page<Contents> contentsPage = contentsRepository
-                                .findBySeriesIdAndStatusAndMedia_PublicStatusOrderByIdAsc(targetSeriesId, Status.ACTIVE, PublicStatus.PUBLIC, pageable);               
+                                .findBySeriesIdAndStatusAndMedia_PublicStatusAndMedia_MediaStatusOrderByIdAsc(targetSeriesId, Status.ACTIVE, PublicStatus.PUBLIC, MediaStatus.COMPLETED, pageable);
                 
               
                 // 시리즈의 에피소드들의 mediaId 추출 
@@ -133,7 +130,7 @@ public class SeriesService {
         private Long getFirstEpisodeMediaId(Long seriesId) {
                 Pageable limitOne = PageRequest.of(0, 1);
                 Page<Contents> firstContentPage = contentsRepository
-                        .findBySeriesIdAndStatusAndMedia_PublicStatusOrderByIdAsc(seriesId, Status.ACTIVE, PublicStatus.PUBLIC, limitOne);
+                        .findBySeriesIdAndStatusAndMedia_PublicStatusAndMedia_MediaStatusOrderByIdAsc(seriesId, Status.ACTIVE, PublicStatus.PUBLIC, MediaStatus.COMPLETED, limitOne);
 
                 if (firstContentPage.isEmpty()) {
                         throw new BusinessException(ErrorCode.EPISODE_NOT_REGISTERED);} // 1화조차 없는 경우 

--- a/modules/domain/src/main/java/com/ott/domain/contents/repository/ContentsRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/contents/repository/ContentsRepository.java
@@ -16,13 +16,38 @@ import com.ott.domain.contents.domain.Contents;
 
 public interface ContentsRepository extends JpaRepository<Contents, Long>, ContentsRepositoryCustom {
 
+        // 상태 추가 중 기존 함수 이름을 유지하기 위해 쿼리로 변경했습니다.
         @EntityGraph(attributePaths = { "media" })
-        Page<Contents> findBySeriesIdAndStatusAndMedia_PublicStatusOrderByIdAsc(Long seriesId, Status status,
-                        PublicStatus publicStatus, Pageable pageable);
+        @Query("""
+                SELECT c FROM Contents c
+                JOIN FETCH c.media m
+                WHERE c.series.id = :seriesId
+                AND c.status = :status
+                AND m.publicStatus = :publicStatus
+                AND m.mediaStatus = com.ott.domain.media.domain.MediaStatus.COMPLETED
+                ORDER BY c.id ASC
+                """)
+        Page<Contents> findBySeriesIdAndStatusAndMedia_PublicStatusOrderByIdAsc(
+                        @Param("seriesId") Long seriesId,
+                        @Param("status") Status status,
+                        @Param("publicStatus") PublicStatus publicStatus,
+                        Pageable pageable);
 
         @EntityGraph(attributePaths = { "media" })
+        @Query("""
+                SELECT c FROM Contents c
+                JOIN FETCH c.media m
+                WHERE c.series.media.id = :seriesMediaId
+                AND c.status = :status
+                AND m.publicStatus = :publicStatus
+                AND m.mediaStatus = com.ott.domain.media.domain.MediaStatus.COMPLETED
+                ORDER BY c.id ASC
+                """)
         Page<Contents> findBySeries_Media_IdAndStatusAndMedia_PublicStatusOrderByIdAsc(
-                        Long seriesMediaId, Status status, PublicStatus publicStatus, Pageable pageable);
+                        @Param("seriesMediaId") Long seriesMediaId,
+                        @Param("status") Status status,
+                        @Param("publicStatus") PublicStatus publicStatus,
+                        Pageable pageable);
 
         // 좋아요 처리 시 series 소속 여부 확인용
         @EntityGraph(attributePaths = {"series", "series.media"})
@@ -40,6 +65,7 @@ public interface ContentsRepository extends JpaRepository<Contents, Long>, Conte
                 WHERE m.id = :mediaId
                 AND c.status = :status
                 AND m.publicStatus = :publicStatus
+                AND m.mediaStatus = com.ott.domain.media.domain.MediaStatus.COMPLETED
                 """)
         Optional<Contents> findByMediaIdAndStatusAndMedia_PublicStatus(
                 @Param("mediaId") Long mediaId,

--- a/modules/domain/src/main/java/com/ott/domain/contents/repository/ContentsRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/contents/repository/ContentsRepository.java
@@ -12,41 +12,19 @@ import org.springframework.data.repository.query.Param;
 import com.ott.domain.common.PublicStatus;
 import com.ott.domain.common.Status;
 import com.ott.domain.contents.domain.Contents;
+import com.ott.domain.media.domain.MediaStatus;
 
 
 public interface ContentsRepository extends JpaRepository<Contents, Long>, ContentsRepositoryCustom {
 
-        // 상태 추가 중 기존 함수 이름을 유지하기 위해 쿼리로 변경했습니다.
         @EntityGraph(attributePaths = { "media" })
-        @Query("""
-                SELECT c FROM Contents c
-                JOIN FETCH c.media m
-                WHERE c.series.id = :seriesId
-                AND c.status = :status
-                AND m.publicStatus = :publicStatus
-                AND m.mediaStatus = com.ott.domain.media.domain.MediaStatus.COMPLETED
-                ORDER BY c.id ASC
-                """)
-        Page<Contents> findBySeriesIdAndStatusAndMedia_PublicStatusOrderByIdAsc(
-                        @Param("seriesId") Long seriesId,
-                        @Param("status") Status status,
-                        @Param("publicStatus") PublicStatus publicStatus,
+        Page<Contents> findBySeriesIdAndStatusAndMedia_PublicStatusAndMedia_MediaStatusOrderByIdAsc(
+                        Long seriesId, Status status, PublicStatus publicStatus, MediaStatus mediaStatus,
                         Pageable pageable);
 
         @EntityGraph(attributePaths = { "media" })
-        @Query("""
-                SELECT c FROM Contents c
-                JOIN FETCH c.media m
-                WHERE c.series.media.id = :seriesMediaId
-                AND c.status = :status
-                AND m.publicStatus = :publicStatus
-                AND m.mediaStatus = com.ott.domain.media.domain.MediaStatus.COMPLETED
-                ORDER BY c.id ASC
-                """)
-        Page<Contents> findBySeries_Media_IdAndStatusAndMedia_PublicStatusOrderByIdAsc(
-                        @Param("seriesMediaId") Long seriesMediaId,
-                        @Param("status") Status status,
-                        @Param("publicStatus") PublicStatus publicStatus,
+        Page<Contents> findBySeries_Media_IdAndStatusAndMedia_PublicStatusAndMedia_MediaStatusOrderByIdAsc(
+                        Long seriesMediaId, Status status, PublicStatus publicStatus, MediaStatus mediaStatus,
                         Pageable pageable);
 
         // 좋아요 처리 시 series 소속 여부 확인용

--- a/modules/domain/src/main/java/com/ott/domain/contents/repository/ContentsRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/contents/repository/ContentsRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.ott.domain.contents.repository;
 
 import com.ott.domain.contents.domain.Contents;
 import com.ott.domain.contents.domain.QContents;
+import com.ott.domain.media.domain.MediaStatus;
 import com.ott.domain.media.domain.QMedia;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -25,7 +26,9 @@ public class ContentsRepositoryImpl implements ContentsRepositoryCustom {
         Contents result = queryFactory
                 .selectFrom(contents)
                 .join(contents.media, media).fetchJoin()
-                .where(contents.id.eq(contentsId))
+                .where(
+                        contents.id.eq(contentsId),
+                        media.mediaStatus.eq(MediaStatus.COMPLETED))
                 .fetchOne();
 
         return Optional.ofNullable(result);
@@ -80,7 +83,10 @@ public class ContentsRepositoryImpl implements ContentsRepositoryCustom {
                 .join(media.uploader, member).fetchJoin()
                 .leftJoin(contents.series, series).fetchJoin()
                 .leftJoin(series.media, seriesMedia).fetchJoin()
-                .where(media.id.eq(mediaId))
+                .where(
+                        media.id.eq(mediaId),
+                        media.mediaStatus.eq(MediaStatus.COMPLETED)
+                )
                 .fetchOne();
 
         return Optional.ofNullable(result);

--- a/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/media/repository/MediaRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.ott.domain.common.MediaType;
 import com.ott.domain.common.PublicStatus;
 import com.ott.domain.common.Status;
 import com.ott.domain.media.domain.Media;
+import com.ott.domain.media.domain.MediaStatus;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -44,7 +45,7 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
 
         
         // ============================================================
-        // 백오피스 관련 쿼라
+        // 백오피스 관련 쿼리
         // ============================================================
 
         @Override
@@ -54,7 +55,8 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
                                 .selectFrom(media)
                                 .where(
                                                 mediaTypeEq(mediaType),
-                                                titleContains(searchWord))
+                                                titleContains(searchWord),
+                                                mediaStatusEq(MediaStatus.COMPLETED))
                                 .orderBy(media.createdDate.desc())
                                 .offset(pageable.getOffset())
                                 .limit(pageable.getPageSize())
@@ -65,7 +67,8 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
                                 .from(media)
                                 .where(
                                                 mediaTypeEq(mediaType),
-                                                titleContains(searchWord));
+                                                titleContains(searchWord),
+                                                mediaStatusEq(MediaStatus.COMPLETED));
 
                 return PageableExecutionUtils.getPage(mediaList, pageable, countQuery::fetchOne);
         }
@@ -78,7 +81,8 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
                                 .where(
                                                 mediaTypeEq(mediaType),
                                                 titleContains(searchWord),
-                                                publicStatusEq(publicStatus))
+                                                publicStatusEq(publicStatus),
+                                                mediaStatusEq(MediaStatus.COMPLETED))
                                 .orderBy(media.createdDate.desc())
                                 .offset(pageable.getOffset())
                                 .limit(pageable.getPageSize())
@@ -90,7 +94,8 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
                                 .where(
                                                 mediaTypeEq(mediaType),
                                                 titleContains(searchWord),
-                                                publicStatusEq(publicStatus));
+                                                publicStatusEq(publicStatus),
+                                                mediaStatusEq(MediaStatus.COMPLETED));
 
                 return PageableExecutionUtils.getPage(mediaList, pageable, countQuery::fetchOne);
         }
@@ -104,7 +109,8 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
                                                 mediaTypeEq(mediaType),
                                                 titleContains(searchWord),
                                                 publicStatusEq(publicStatus),
-                                                uploaderIdEq(uploaderId))
+                                                uploaderIdEq(uploaderId),
+                                                mediaStatusEq(MediaStatus.COMPLETED))
                                 .orderBy(media.createdDate.desc())
                                 .offset(pageable.getOffset())
                                 .limit(pageable.getPageSize())
@@ -117,7 +123,8 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
                                                 mediaTypeEq(mediaType),
                                                 titleContains(searchWord),
                                                 publicStatusEq(publicStatus),
-                                                uploaderIdEq(uploaderId));
+                                                uploaderIdEq(uploaderId),
+                                                mediaStatusEq(MediaStatus.COMPLETED));
 
                 return PageableExecutionUtils.getPage(mediaList, pageable, countQuery::fetchOne);
         }
@@ -137,7 +144,8 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
                                 .selectFrom(media)
                                 .where(
                                                 condition,
-                                                titleContains(searchWord))
+                                                titleContains(searchWord),
+                                                mediaStatusEq(MediaStatus.COMPLETED))
                                 .orderBy(media.createdDate.desc())
                                 .offset(pageable.getOffset())
                                 .limit(pageable.getPageSize())
@@ -146,7 +154,10 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
                 JPAQuery<Long> countQuery = queryFactory
                                 .select(media.count())
                                 .from(media)
-                                .where(condition, titleContains(searchWord));
+                                .where(
+                                                condition,
+                                                titleContains(searchWord),
+                                                mediaStatusEq(MediaStatus.COMPLETED));
 
                 return PageableExecutionUtils.getPage(mediaList, pageable, countQuery::fetchOne);
         }
@@ -165,6 +176,7 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
                                 media.status.eq(Status.ACTIVE),
                                 media.publicStatus.eq(PublicStatus.PUBLIC),
                                 mediaTag.tag.id.eq(tagId),
+                                mediaStatusEq(MediaStatus.COMPLETED),
                                 excludeMediaId != null ? media.id.ne(excludeMediaId) : null)
                         .orderBy(media.id.desc())
                         .limit(limit)
@@ -194,6 +206,7 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
                         .where(
                                 media.status.eq(ACTIVE),
                                 media.publicStatus.eq(PUBLIC),
+                                mediaStatusEq(MediaStatus.COMPLETED),
                                 // 시리즈 자체 OR 단편 콘텐츠 (시리즈 에피소드 제외)
                                 media.mediaType.eq(SERIES)
                                         .or(media.mediaType.eq(CONTENTS).and(contents.id.isNotNull()))
@@ -495,9 +508,10 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
         }
 
         private BooleanExpression isActiveAndPublic() {
-                // Status.ACTIVE와 PublicStatus.PUBLIC 조건을 결합
+                // Status.ACTIVE와 PublicStatus.PUBLIC 조건을 결합 + Status.COMPLETED
                 return media.status.eq(Status.ACTIVE)
-                                .and(media.publicStatus.eq(PublicStatus.PUBLIC));
+                                .and(media.publicStatus.eq(PublicStatus.PUBLIC)
+                                        .and(media.mediaStatus.eq(MediaStatus.COMPLETED)));
         }
 
         private BooleanExpression excludeId(Long excludeMediaId) {
@@ -514,4 +528,10 @@ public class MediaRepositoryImpl implements MediaRepositoryCustom {
                                                 .and(contents.series.isNotNull()))
                                         .notExists()));
        }
+
+        private BooleanExpression mediaStatusEq(MediaStatus mediaStatus) {
+                if (mediaStatus != null)
+                        return media.mediaStatus.eq(mediaStatus);
+                return null;
+        }
 }

--- a/modules/domain/src/main/java/com/ott/domain/media_metrics/repository/MediaMetricsJdbcRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/media_metrics/repository/MediaMetricsJdbcRepository.java
@@ -28,6 +28,7 @@ public class MediaMetricsJdbcRepository {
                 FROM media
                 WHERE status = 'ACTIVE'
                 AND public_status = 'PUBLIC'
+                AND media_status = 'COMPLETED'
                 """;
         return jdbcTemplate.query(sql, SCORE_MAPPER);
     }
@@ -50,6 +51,7 @@ public class MediaMetricsJdbcRepository {
                     WHERE c.series_id IS NULL
                       AND c.duration > 0
                       AND p.status = 'ACTIVE'
+                      AND media_status = 'COMPLETED'
                     GROUP BY c.media_id
 
                     UNION ALL
@@ -93,6 +95,7 @@ public class MediaMetricsJdbcRepository {
                     WHERE c.series_id IS NULL
                       AND wh.status = 'ACTIVE'
                       AND m.status = 'ACTIVE'
+                      AND media_status = 'COMPLETED'
                       AND m.public_status = 'PUBLIC'
                     GROUP BY c.media_id, m.bookmark_count
 
@@ -107,6 +110,7 @@ public class MediaMetricsJdbcRepository {
                     WHERE wh.status = 'ACTIVE'
                       AND m.status = 'ACTIVE'
                       AND m.public_status = 'PUBLIC'
+                      AND media_status = 'COMPLETED'
                     GROUP BY s.media_id, m.bookmark_count
                 ) raw_data
                 """;
@@ -121,6 +125,7 @@ public class MediaMetricsJdbcRepository {
                 FROM media
                 WHERE status = 'ACTIVE'
                 AND public_status = 'PUBLIC'
+                AND media_status = 'COMPLETED'
                 """;
         return jdbcTemplate.query(sql, SCORE_MAPPER);
     }
@@ -141,6 +146,7 @@ public class MediaMetricsJdbcRepository {
                     JOIN contents c ON wh.contents_id = c.id
                     WHERE c.series_id IS NULL
                       AND wh.status = 'ACTIVE'
+                      AND media_status = 'COMPLETED'
                     GROUP BY c.media_id
 
                     UNION ALL

--- a/modules/domain/src/main/java/com/ott/domain/media_metrics/repository/MediaMetricsRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/media_metrics/repository/MediaMetricsRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.ott.domain.common.MediaType;
 import com.ott.domain.common.PublicStatus;
 import com.ott.domain.common.Status;
 import com.ott.domain.media.domain.Media;
+import com.ott.domain.media.domain.MediaStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
@@ -40,6 +41,7 @@ public class MediaMetricsRepositoryImpl implements MediaMetricsRepositoryCustom 
                 .where(
                         media.status.eq(Status.ACTIVE),
                         media.publicStatus.eq(PublicStatus.PUBLIC),
+                        media.mediaStatus.eq(MediaStatus.COMPLETED), // 유저에게 보여주는 추천 쿼리
                         media.mediaType.eq(MediaType.SERIES)
                                 .or(media.mediaType.eq(MediaType.CONTENTS)
                                         .and(JPAExpressions.selectOne()

--- a/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepository.java
+++ b/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepository.java
@@ -15,7 +15,7 @@ import com.ott.domain.series.domain.Series;
 public interface SeriesRepository extends JpaRepository<Series, Long>, SeriesRepositoryCustom {
 
         // 미디어 Id 로 해당 시리즈 조회
-        @Query("SELECT s FROM Series s JOIN FETCH s.media m WHERE m.id = :mediaId AND s.status = :status AND m.publicStatus = :publicStatus")
+        @Query("SELECT s FROM Series s JOIN FETCH s.media m WHERE m.id = :mediaId AND s.status = :status AND m.publicStatus = :publicStatus AND m.mediaStatus = com.ott.domain.media.domain.MediaStatus.COMPLETED")
         Optional<Series> findByMediaIdAndStatusAndPublicStatus(
                         @Param("mediaId") Long mediaId,
                         @Param("status") Status status,

--- a/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/series/repository/SeriesRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.ott.domain.series.repository;
 
 import com.ott.domain.series.domain.Series;
+import com.ott.domain.media.domain.MediaStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -39,7 +40,9 @@ public class SeriesRepositoryImpl implements SeriesRepositoryCustom {
                 .selectFrom(series)
                 .join(series.media, media).fetchJoin()
                 .join(media.uploader, member).fetchJoin()
-                .where(media.id.eq(mediaId))
+                .where(
+                        media.id.eq(mediaId),
+                        media.mediaStatus.eq(MediaStatus.COMPLETED))
                 .fetchOne();
 
         return Optional.ofNullable(result);
@@ -50,7 +53,10 @@ public class SeriesRepositoryImpl implements SeriesRepositoryCustom {
         List<Series> seriesList = queryFactory
                 .selectFrom(series)
                 .join(series.media, media).fetchJoin()
-                .where(titleContains(searchWord))
+                .where(
+                        titleContains(searchWord),
+                        media.mediaStatus.eq(MediaStatus.COMPLETED)
+                )
                 .orderBy(series.createdDate.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -60,7 +66,9 @@ public class SeriesRepositoryImpl implements SeriesRepositoryCustom {
                 .select(series.count())
                 .from(series)
                 .join(series.media, media)
-                .where(titleContains(searchWord));
+                .where(titleContains(searchWord),
+                        media.mediaStatus.eq(MediaStatus.COMPLETED)
+                );
 
         return PageableExecutionUtils.getPage(seriesList, pageable, countQuery::fetchOne);
     }
@@ -69,7 +77,9 @@ public class SeriesRepositoryImpl implements SeriesRepositoryCustom {
     public List<Series> findAllByMediaIdIn(List<Long> mediaIdList) {
         return queryFactory
                 .selectFrom(series)
-                .where(series.media.id.in(mediaIdList))
+                .where(
+                        series.media.id.in(mediaIdList),
+                        media.mediaStatus.eq(MediaStatus.COMPLETED))
                 .fetch();
     }
 

--- a/modules/domain/src/main/java/com/ott/domain/short_form/repository/ShortFormRepositoryImpl.java
+++ b/modules/domain/src/main/java/com/ott/domain/short_form/repository/ShortFormRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.ott.domain.short_form.repository;
 import com.ott.domain.common.Status;
 import com.ott.domain.media.domain.QMedia;
 import com.ott.domain.short_form.domain.ShortForm;
+import com.ott.domain.media.domain.MediaStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
@@ -39,7 +40,9 @@ public class ShortFormRepositoryImpl implements ShortFormRepositoryCustom {
                 .leftJoin(contents.media, contentsMedia).fetchJoin()
                 .leftJoin(shortForm.series, series).fetchJoin()
                 .leftJoin(series.media, seriesMedia).fetchJoin()
-                .where(media.id.eq(mediaId))
+                .where(
+                        media.id.eq(mediaId),
+                        media.mediaStatus.eq(MediaStatus.COMPLETED))
                 .fetchOne();
 
         return Optional.ofNullable(result);
@@ -58,7 +61,9 @@ public class ShortFormRepositoryImpl implements ShortFormRepositoryCustom {
                 .leftJoin(contents.media, contentsMedia).fetchJoin()
                 .leftJoin(shortForm.series, series).fetchJoin()
                 .leftJoin(series.media, seriesMedia).fetchJoin()
-                .where(shortForm.id.eq(shortFormId))
+                .where(
+                        shortForm.id.eq(shortFormId),
+                        media.mediaStatus.eq(MediaStatus.COMPLETED))
                 .fetchOne();
 
         return Optional.ofNullable(result);
@@ -87,7 +92,8 @@ public class ShortFormRepositoryImpl implements ShortFormRepositoryCustom {
             return queryFactory.selectFrom(shortForm)
                     .leftJoin(shortForm.series, series)
                     .leftJoin(shortForm.contents, contents)
-                    .where(shortForm.status.eq(Status.ACTIVE)) // 활성 상태의 숏폼만
+                    .where(shortForm.status.eq(Status.ACTIVE),
+                            shortForm.media.mediaStatus.eq(MediaStatus.COMPLETED)) // 활성 상태의 숏폼만
                     // 무한 스와이프를 위해 DB에서 정렬 후 자름
                     .orderBy(originBookmarkCount.desc().nullsLast(), shortForm.createdDate.desc(), shortForm.id.desc())
                     .limit(limit)
@@ -116,7 +122,8 @@ public class ShortFormRepositoryImpl implements ShortFormRepositoryCustom {
                         shortForm.series.isNotNull().and(mediaTag.media.id.eq(series.media.id))
                         .or(shortForm.series.isNull().and(mediaTag.media.id.eq(contents.media.id)))
                 )
-                .where(shortForm.status.eq(Status.ACTIVE)) // 활성 상태의 숏폼만
+                .where(shortForm.status.eq(Status.ACTIVE),
+                        shortForm.media.mediaStatus.eq(MediaStatus.COMPLETED)) // 활성 상태의 숏폼만
                 .groupBy(shortForm.id)
                 .orderBy(scoreExpression.sum().desc(), shortForm.createdDate.desc(), shortForm.id.desc())
                 .limit(limit)
@@ -135,7 +142,8 @@ public class ShortFormRepositoryImpl implements ShortFormRepositoryCustom {
         return queryFactory.selectFrom(shortForm)
                 .where(
                         excludeCondition,
-                        shortForm.status.eq(Status.ACTIVE) // 활성 상태의 숏폼만
+                        shortForm.status.eq(Status.ACTIVE),
+                        shortForm.media.mediaStatus.eq(MediaStatus.COMPLETED)// 활성 상태의 숏폼만
                 )
                 .orderBy(shortForm.createdDate.desc(), shortForm.id.desc()) // 무조건 최신 업로드 순
                 .limit(limit)


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 미디어, 숏폼, 시리즈, 숏폼 타입에 따른 조회 시 상태 조건 추가했습니다.
- [x] 각자 작성한 쿼리가 다르기 때문에 각 파트별 담당자분들이 별도로 확인해주시면 감사하겠습니다.
          
----                                                                                              
   ## 쿼리 분류 기준                                                                                                                                      
  ### COMPLETED 조건을 추가한 쿼리들                                                                                                          
                                                                                                                                          
  기준: 사용자나 관리자가 "콘텐츠를 보거나 편집"하는 경우                                                                                 
                                                                                                                                          
  트랜스코딩이 완료된 영상만 재생 가능하고, 미완료 영상을 화면에 노출하는 건 사용자 경험상 의미가 없음. 
  관리자가 편집하는 경우도 마찬가지 -> 아직 처리 중이거나 실패한 영상을 수정하는 건 맞지 않음.
                                                                                                                                          
  - 유저 API: 피드, 검색, 시리즈 상세, 숏폼 피드 등                                                                                       
  - 관리자 목록/상세/편집 API: 콘텐츠 수정, 시리즈 편집 등
  - 추천 알고리즘: 점수 기반 추천 (findTopByWeightedScore)                                                                                
                                                                                                                                          
  ---                                                                                                                                     
  ### COMPLETED 조건을 추가하지 않은 쿼리들                                                                                                   
                                                                                                                                          
  **기준 1: 트랜스코딩 모니터링 페이지 (/back-office/ingest-jobs)**
                                                                                                                                          
  이 페이지의 목적 자체가 트랜스코딩 진행 상황을 보는 것. 여기서 COMPLETED만 보이면 PENDING/PROCESSING/FAILED 상태인 작업이 화면에서  사라져서 모니터링이 불가능해짐.                                                                                                         
                                                                                                                                          
  - IngestJobRepositoryImpl 전체                                                                                                          
  - findAllByMediaIdIn (Contents/Series/ShortForm) -> IngestJob 목록에서 관련 미디어 타이틀을 보여주기 위해 사용하는 쿼리

 **기준 2: 북마크 / 좋아요 / 댓글 / 시청기록**                                                                                               
                                                                                                                                          
  이 데이터는 사용자가 실제로 영상을 봤을 때 생성됨. 영상을 보려면 반드시 COMPLETED 상태여야 하기 때문에, 이 테이블에 있는 레코드는 이미  "COMPLETED였던 미디어"에 대한 기록. 별도로 COMPLETED 조건을 걸어도 결과가 동일하고, 오히려 불필요한 join이 늘어남.
                                                                                                                                          
  **기준 3: 트랜스코더 내부 쿼리**                                                                                                            
   
  트랜스코더가 미디어 상태를 INIT → COMPLETED로 변경하는 주체. 트랜스코더가 COMPLETED 조건으로 조회하면 자기 자신이 처리해야 할 미디어를 못 찾아서 트랜스코딩 자체가 불가능해짐.

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
close #212 


## 💬 리뷰 요구사항
각 담당자마다 작성했던 쿼리 위주로 봐주시면 됩니다.
로컬에서 테스트는 수정 이후 잘 작동합니다.
